### PR TITLE
patch: bump d2-analysis version with interpretation sort order fix [DHIS2-5472]

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-reports-app#readme",
   "dependencies": {
-    "d2-analysis": "32.0.2",
+    "d2-analysis": "32.0.3",
     "d2-utilizr": "0.2.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@32.0.2:
-  version "32.0.2"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-32.0.2.tgz#4a803cd0ea614f8a6fca94c8989b388726e29084"
-  integrity sha512-c4UVfk87cjCOenU8AQ4xW3r3yS+O2ZxHtFu18zbfkDIZlxGYYU0YgQ4J26r/t7NQmyl/z61A4THLsT3pUXEm5w==
+d2-analysis@32.0.3:
+  version "32.0.3"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-32.0.3.tgz#a2563bb445776961c6e9bc4cbfec3fc7689933fd"
+  integrity sha512-ZTg6brT1rqozD42z9UddEJ01gdfQP7l5TI42ALcJS8Jf67q6VqyNe/S2qBPzAntr8a81d9A0eVcXZbRCZj2N5Q==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
This PR includes latest version of d2-analysis with interpretation [sort order fix](https://jira.dhis2.org/browse/DHIS2-5472)