### PR TITLE
feat: sort by event date by default for events

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -313,7 +313,7 @@ Layout.prototype.req = function(source, format, isSorted, isTableLayout, isFilte
             ) {
                 request.add(this.sorting.direction.toLowerCase() + '=' + this.sorting.id);
             } else {
-                request.add('asc=eventdate'); // default sort by event date
+                request.add('desc=eventdate'); // default sort by event date
             }
         }
 

--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -305,12 +305,15 @@ Layout.prototype.req = function(source, format, isSorted, isTableLayout, isFilte
         }
 
         // sorting
-        if (
-            isObject(this.sorting) &&
-            this.dataType === dimensionConfig.dataType['individual_cases']
-        ) {
-            if (isString(this.sorting.direction) && isString(this.sorting.id)) {
+        if (this.dataType === dimensionConfig.dataType['individual_cases']) {
+            if (
+                isObject(this.sorting) &&
+                isString(this.sorting.direction) &&
+                isString(this.sorting.id)
+            ) {
                 request.add(this.sorting.direction.toLowerCase() + '=' + this.sorting.id);
+            } else {
+                request.add('asc=eventdate'); // default sort by event date
             }
         }
 


### PR DESCRIPTION
Fixes [DHIS2-5582](https://jira.dhis2.org/browse/DHIS2-5582?filter=-1).

This PR enables default sorting (by `eventdate`)  settings for events.