### PR TITLE
chore: Upgrade d2-analysis to enable incident/enrollment dates for events

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-reports-app#readme",
   "dependencies": {
-    "d2-analysis": "33.0.0",
+    "d2-analysis": "33.0.1",
     "d2-utilizr": "0.2.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@33.0.0:
-  version "33.0.0"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.0.0.tgz#ec88d8b79314961b842822495452acf80f8deaaf"
-  integrity sha512-WSYJbcGCfs2O+U6wgUShd8jYtOJH7i21Z39azCK3NjoDgLx3Cofe+KOz+ZBm4okPvMo9YgS+FxkRCH8ACLXvUQ==
+d2-analysis@33.0.1:
+  version "33.0.1"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.0.1.tgz#0167e06d2d281f4b44b4c1057c455fe8a21679a5"
+  integrity sha512-qj/x82ljJh092+H2Hk6+RvWTohAkhg/jUYAmRrxZqnnzg9Kk8sMGRCfo7noUvfLOzcqPOQUdvvJO/nX4urLy2Q==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
Relates to [DHIS2-2480](https://jira.dhis2.org/browse/DHIS2-2480).

Changes include:
- Upgrade `d2-analysis` dependency version to 33.0.1