### PR TITLE
chore: Update d2-analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-reports-app#readme",
   "dependencies": {
-    "d2-analysis": "33.1.0",
+    "d2-analysis": "33.1.1",
     "d2-utilizr": "0.2.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@33.1.0:
-  version "33.1.0"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.1.0.tgz#a938abc92e2698429ae8d77ed1ce1da28e45d1db"
-  integrity sha512-MQ28fLB82VopgSYQmFTKbO9erc+KeLrPVv7r/27ZhTbRX4iikIeRynnDv8x8yObARDICXbYkQd7I+GMy3zkHbg==
+d2-analysis@33.1.1:
+  version "33.1.1"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.1.1.tgz#0f6abab825a59a0e0f55d2acd496515e5b63a577"
+  integrity sha512-W+pcgXZ1bxLQm7m7hYw+hJ/0kkE7CVnEEPnn3J7DZamOTGsEXSAOjXGiMbacwPbLBKc5Ztu3rOsiqlw69dzFGg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
Fixes [DHIS2-6868](https://jira.dhis2.org/browse/DHIS2-6868).

Changes include:
- Updating d2-analysis to v33.1.1 to enable support for data elements with multiple filters (date & numeric value types).