### PR TITLE
fix: Make styles more specific to app/plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="initial-scale=1"/>
 </head>
-<body>
+<body class="event-reports-app">
 <div id="init">
     <div id="inittext"><span class="brand">DHIS 2</span>Event Reports</div>
     <div class="spinner"></div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -38,7 +38,7 @@
  * General
  *--------------------------------------------------------------------------*/
 
-body * {
+body.event-reports-app * {
 	font-family: 'Helvetica Neue','Helvetica','Arial','sans-serif' !important;
 }
 


### PR DESCRIPTION
App styles (`body * { font-family: Helvetica Neue, sans-serif !important }`) cause font issues on plugin import in other apps (e.g. dashboards app).

Proposed changes make styles more specific to event reports app by using body class selector.