### PR TITLE
feat: FileMenu in MenuBar and loading of visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# [33.3.0](https://github.com/dhis2/event-reports-app/compare/v33.2.22...v33.3.0) (2021-10-04)
+
+
+### Bug Fixes
+
+* empty schemas ([29e47a2](https://github.com/dhis2/event-reports-app/commit/29e47a2a8982f672f0be1ee004dbf6a1aecbb7b7))
+* linelist config ([bd87f04](https://github.com/dhis2/event-reports-app/commit/bd87f044149b7b8b81593a08967084d950f92fac))
+* visualization -> eventReport ([e1ea53f](https://github.com/dhis2/event-reports-app/commit/e1ea53f3fb01e364a06effd0d54447b3e110ea42))
+
+
+### Features
+
+* basic imports and first draft of the options modal ([d8f9181](https://github.com/dhis2/event-reports-app/commit/d8f918135c0b6653b2e45c807f728a3514d6b520))
+* options modal ([#824](https://github.com/dhis2/event-reports-app/issues/824)) ([f4fdc1a](https://github.com/dhis2/event-reports-app/commit/f4fdc1a36d36bcb3ea6e7ceba9da2166a74a92b1))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "event-reports-app",
-    "version": "100.0.0",
+    "version": "33.3.0",
     "description": "",
     "license": "BSD-3-Clause",
     "private": true,

--- a/src/actions/current.js
+++ b/src/actions/current.js
@@ -1,0 +1,10 @@
+import { SET_CURRENT, CLEAR_CURRENT } from '../reducers/current'
+
+export const acSetCurrent = value => ({
+    type: SET_CURRENT,
+    value,
+})
+
+export const acClearCurrent = () => ({
+    type: CLEAR_CURRENT,
+})

--- a/src/actions/visualization.js
+++ b/src/actions/visualization.js
@@ -3,9 +3,9 @@ import {
     CLEAR_VISUALIZATION,
 } from '../reducers/visualization'
 
-export const acSetVisualization = visualization => ({
+export const acSetVisualization = value => ({
     type: SET_VISUALIZATION,
-    value: visualization,
+    value,
 })
 
 export const acClearVisualization = () => ({

--- a/src/actions/visualization.js
+++ b/src/actions/visualization.js
@@ -1,0 +1,13 @@
+import {
+    SET_VISUALIZATION,
+    CLEAR_VISUALIZATION,
+} from '../reducers/visualization'
+
+export const acSetVisualization = visualization => ({
+    type: SET_VISUALIZATION,
+    value: visualization,
+})
+
+export const acClearVisualization = () => ({
+    type: CLEAR_VISUALIZATION,
+})

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,7 +17,7 @@ const visualizationQuery = {
     eventReport: {
         resource: 'eventReports',
         id: ({ id }) => id,
-        // TODO copy pasted from old ER
+        // TODO check if this list is what we need/want (copied from old ER)
         params: {
             fields: '*,interpretations[*,user[id,displayName,userCredentials[username]],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName,userCredentials[username]]]],columns[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],rows[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],filters[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],program[id,displayName~rename(name),enrollmentDateLabel,incidentDateLabel],programStage[id,displayName~rename(name),executionDateLabel],access,userGroupAccesses,publicAccess,displayDescription,user[displayName,userCredentials[username]],href,!rewindRelativePeriods,!userOrganisationUnit,!userOrganisationUnitChildren,!userOrganisationUnitGrandChildren,!externalAccess,!relativePeriods,!columnDimensions,!rowDimensions,!filterDimensions,!organisationUnitGroups,!itemOrganisationUnitGroups,!indicators,!dataElements,!dataElementOperands,!dataElementGroups,!dataSets,!periods,!organisationUnitLevels,!organisationUnits,dataElementDimensions[legendSet[id,name],dataElement[id,name]]',
         },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,20 +1,113 @@
-import React from 'react'
+import { useDataQuery } from '@dhis2/app-runtime'
+import PropTypes from 'prop-types'
+import React, { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
+import { acClearCurrent, acSetCurrent } from '../actions/current'
+import {
+    acClearVisualization,
+    acSetVisualization,
+} from '../actions/visualization'
+import history from '../modules/history'
+import { sGetCurrent } from '../reducers/current'
+import { sGetVisualization } from '../reducers/visualization'
 import classes from './App.module.css'
-import VisualizationOptionsManager from './VisualizationOptions/VisualizationOptionsManager'
+import { Toolbar } from './Toolbar/Toolbar'
 
-const App = () => (
-    <>
+const visualizationQuery = {
+    eventReport: {
+        resource: 'eventReports',
+        id: ({ id }) => id,
+        // TODO copy pasted from old ER
+        params: {
+            fields: '*,interpretations[*,user[id,displayName,userCredentials[username]],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName,userCredentials[username]]]],columns[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],rows[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],filters[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],program[id,displayName~rename(name),enrollmentDateLabel,incidentDateLabel],programStage[id,displayName~rename(name),executionDateLabel],access,userGroupAccesses,publicAccess,displayDescription,user[displayName,userCredentials[username]],href,!rewindRelativePeriods,!userOrganisationUnit,!userOrganisationUnitChildren,!userOrganisationUnitGrandChildren,!externalAccess,!relativePeriods,!columnDimensions,!rowDimensions,!filterDimensions,!organisationUnitGroups,!itemOrganisationUnitGroups,!indicators,!dataElements,!dataElementOperands,!dataElementGroups,!dataSets,!periods,!organisationUnitLevels,!organisationUnits,dataElementDimensions[legendSet[id,name],dataElement[id,name]]',
+        },
+    },
+}
+
+const App = ({
+    location,
+    visualization,
+    clearCurrent,
+    clearVisualization,
+    setCurrent,
+    setVisualization,
+}) => {
+    const [previousLocation, setPreviousLocation] = useState(null)
+    const [initialLoadIsComplete, setInitialLoadIsComplete] = useState(false)
+    const { data, refetch } = useDataQuery(visualizationQuery, {
+        lazy: true,
+    })
+
+    const needsRefetch = location => {
+        if (!previousLocation) {
+            return true
+        }
+
+        const id = location.pathname.slice(1).split('/')[0]
+        const prevId = previousLocation.slice(1).split('/')[0]
+
+        if (id !== prevId || previousLocation === location.pathname) {
+            return true
+        }
+
+        return false
+    }
+
+    const parseLocation = location => {
+        const pathParts = location.pathname.slice(1).split('/')
+        const id = pathParts[0]
+        const interpretationId = pathParts[2]
+        return { id, interpretationId }
+    }
+
+    const loadVisualization = location => {
+        if (location.pathname.length > 1) {
+            // /currentAnalyticalObject
+            // /${id}/
+            // /${id}/interpretation/${interpretationId}
+            const { id } = parseLocation(location)
+
+            if (needsRefetch(location)) {
+                refetch({ id })
+            }
+        } else {
+            clearCurrent()
+            clearVisualization()
+        }
+
+        setInitialLoadIsComplete(true)
+        setPreviousLocation(location.pathname)
+    }
+
+    useEffect(() => {
+        loadVisualization(location)
+
+        const unlisten = history.listen(({ location }) => {
+            const isSaving = location.state?.isSaving
+            const isOpening = location.state?.isOpening
+
+            if (
+                isSaving ||
+                isOpening ||
+                previousLocation !== location.pathname
+            ) {
+                loadVisualization(location)
+            }
+        })
+
+        return () => unlisten && unlisten()
+    }, [])
+
+    useEffect(() => {
+        if (data?.eventReport) {
+            setVisualization(data.eventReport)
+            setCurrent(data.eventReport)
+        }
+    }, [data])
+
+    return (
         <div className={`${classes.eventReportsApp} flex-ct flex-dir-col`}>
-            <div className={`${classes.sectionToolbar} ${classes.flexCt}`}>
-                <div className={classes.toolbarType}>{'vis type selector'}</div>
-                <div
-                    className={`${classes.toolbarMenubar} ${classes.flexGrow1}`}
-                >
-                    {'menubar'}
-                    <VisualizationOptionsManager />
-                </div>
-            </div>
+            <Toolbar />
             <div
                 className={`${classes.sectionMain} ${classes.flexGrow1} ${classes.flexCt}`}
             >
@@ -29,22 +122,37 @@ const App = () => (
                     <div
                         className={`${classes.mainCenterCanvas} ${classes.flexGrow1}`}
                     >
-                        {'visualization'}
+                        {initialLoadIsComplete
+                            ? visualization
+                                ? visualization.name
+                                : 'start screen'
+                            : 'loading...'}
                     </div>
                 </div>
             </div>
         </div>
-    </>
-)
+    )
+}
 
-const mapStateToProps = () => ({})
+const mapStateToProps = state => ({
+    current: sGetCurrent(state),
+    visualization: sGetVisualization(state),
+})
 
-const mapDispatchToProps = {}
+const mapDispatchToProps = {
+    clearVisualization: acClearVisualization,
+    clearCurrent: acClearCurrent,
+    setCurrent: acSetCurrent,
+    setVisualization: acSetVisualization,
+}
 
-App.contextTypes = {}
-
-App.childContextTypes = {}
-
-App.propTypes = {}
+App.propTypes = {
+    clearCurrent: PropTypes.func,
+    clearVisualization: PropTypes.func,
+    location: PropTypes.object,
+    setCurrent: PropTypes.func,
+    setVisualization: PropTypes.func,
+    visualization: PropTypes.object,
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(App)

--- a/src/components/Toolbar/MenuBar.js
+++ b/src/components/Toolbar/MenuBar.js
@@ -1,0 +1,66 @@
+import { FileMenu } from '@dhis2/analytics'
+import { useD2 } from '@dhis2/app-runtime-adapter-d2'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { connect } from 'react-redux'
+import history from '../../modules/history'
+import { sGetCurrent } from '../../reducers/current'
+import VisualizationOptionsManager from '../VisualizationOptions/VisualizationOptionsManager'
+import classes from './styles/MenuBar.module.css'
+
+const onOpen = id => {
+    const path = `/${id}`
+    if (history.location.pathname === path) {
+        history.replace({ pathname: path, state: { isOpening: true } })
+    } else {
+        history.push(path)
+    }
+}
+const onNew = () => {
+    if (history.location.pathname === '/') {
+        history.replace({ pathname: '/', state: { isResetting: true } })
+    } else {
+        history.push('/')
+    }
+}
+const getOnRename = () => details =>
+    console.log('rename not implemented', details)
+const getOnSave = () => details => console.log('save not implemented', details)
+const getOnSaveAs = () => details =>
+    console.log('save as not implemented', details)
+const getOnDelete = () => () => console.log('delete not implemented')
+const getOnError = () => error => console.error('Error', error)
+
+export const MenuBar = ({ dataTest, current, apiObjectName, ...props }) => {
+    const { d2 } = useD2()
+
+    return (
+        <div className={classes.menuBar} data-test={dataTest}>
+            <FileMenu
+                d2={d2}
+                fileType={apiObjectName}
+                fileObject={current}
+                onOpen={onOpen}
+                onNew={onNew}
+                onRename={getOnRename(props)}
+                onSave={getOnSave(props)}
+                onSaveAs={getOnSaveAs(props)}
+                onDelete={getOnDelete(props)}
+                onError={getOnError(props)}
+            />
+            <VisualizationOptionsManager />
+        </div>
+    )
+}
+
+MenuBar.propTypes = {
+    apiObjectName: PropTypes.string,
+    current: PropTypes.object,
+    dataTest: PropTypes.string,
+}
+
+const mapStateToProps = state => ({
+    current: sGetCurrent(state),
+})
+
+export default connect(mapStateToProps)(MenuBar)

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import classes from '../App.module.css'
+import { MenuBar } from './MenuBar'
+
+const apiObjectName = 'eventReport' // TODO move to App?
+
+export const Toolbar = () => {
+    return (
+        <div className={`${classes.sectionToolbar} ${classes.flexCt}`}>
+            <div className={classes.toolbarType}>{'vis type selector'}</div>
+            <MenuBar apiObjectName={apiObjectName} dataTest={'app-menubar'} />
+        </div>
+    )
+}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import classes from '../App.module.css'
-import { MenuBar } from './MenuBar'
+import { default as MenuBar } from './MenuBar'
 
 const apiObjectName = 'eventReport' // TODO move to App?
 

--- a/src/components/Toolbar/styles/MenuBar.module.css
+++ b/src/components/Toolbar/styles/MenuBar.module.css
@@ -1,0 +1,13 @@
+.menuBar {
+    background: var(--colors-white);
+    display: flex;
+    align-items: center;
+    padding: 0 var(--spacers-dp8);
+    height: 38px;
+}
+.updateButton {
+    margin-right: var(--spacers-dp8);
+}
+.flexGrow {
+    flex-grow: 1;
+}

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -10,7 +10,7 @@ const configureStore = middleware => {
         typeof window === 'object' &&
         window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
             ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-                  name: 'data-visualizer-app',
+                  name: 'event-reports-app',
               })
             : compose
 

--- a/src/reducers/current.js
+++ b/src/reducers/current.js
@@ -1,0 +1,21 @@
+export const SET_CURRENT = 'SET_CURRENT'
+export const SET_CURRENT_FROM_UI = 'SET_CURRENT_FROM_UI'
+export const CLEAR_CURRENT = 'CLEAR_CURRENT'
+
+export const DEFAULT_CURRENT = null
+
+export default (state = DEFAULT_CURRENT, action) => {
+    switch (action.type) {
+        case SET_CURRENT: {
+            return action.value
+        }
+        case CLEAR_CURRENT:
+            return DEFAULT_CURRENT
+        default:
+            return state
+    }
+}
+
+// Selectors
+
+export const sGetCurrent = state => state.current

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,10 +1,14 @@
 import { combineReducers } from 'redux'
+import current from './current'
 import metadata from './metadata'
 import ui from './ui'
+import visualization from './visualization'
 
 // Reducers
 
 export default combineReducers({
-    ui,
+    current,
     metadata,
+    ui,
+    visualization,
 })

--- a/src/reducers/visualization.js
+++ b/src/reducers/visualization.js
@@ -1,0 +1,23 @@
+export const SET_VISUALIZATION = 'SET_VISUALIZATION'
+export const CLEAR_VISUALIZATION = 'CLEAR_VISUALIZATION'
+
+export const DEFAULT_VISUALIZATION = null
+
+export default (state = DEFAULT_VISUALIZATION, action) => {
+    switch (action.type) {
+        case SET_VISUALIZATION: {
+            return action.value
+        }
+        case CLEAR_VISUALIZATION: {
+            return DEFAULT_VISUALIZATION
+        }
+        default:
+            return state
+    }
+}
+
+// Selectors
+
+export const sGetVisualization = state => state.visualization
+export const sGetInterpretations = state =>
+    state.visualization ? state.visualization.interpretations : []


### PR DESCRIPTION
The PR has a bit more than that, since navigation had to be implemented too.
Now it's possible to load a ER (Line list only) visualization from the `FileMenu` or from the URL.
Both `visualization` and `current` are set when a visualization is loaded.
The actual fetch uses `useDataQuery` hook directly in the `App` component.

The New button in the FileMenu also works and cleans the Redux store.

### Notes
* Some parts from DV have been omitted but we likely need them, for example the loading of the visualization from the user data store.
* I'm not sure about the interpretation part, since the component is going to be rewritten from scratch. In current DV the URL can contain the interpretation id and in that case the right panel opens showing the interpretation.

### Screenshots
<img width="866" alt="Screenshot 2021-10-05 at 07 29 53" src="https://user-images.githubusercontent.com/150978/135965783-ed700861-1ff1-4bfc-8738-d7ce30614f6c.png">
<img width="877" alt="Screenshot 2021-10-05 at 07 30 05" src="https://user-images.githubusercontent.com/150978/135965800-22788fca-9dad-4c74-8697-071cac16b4f6.png">
<img width="872" alt="Screenshot 2021-10-05 at 07 30 12" src="https://user-images.githubusercontent.com/150978/135965810-795dc6fa-e40d-49d0-b1ae-b1f49bc8a7cd.png">


