### PR TITLE
feat: populate metadata in store and use it to display item names in DataTable

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 import { connect } from 'react-redux'
 import { acClearCurrent, acSetCurrent } from '../actions/current'
+import { acAddMetadata } from '../actions/metadata'
 import { acSetUser } from '../actions/user'
 import {
     acClearVisualization,
@@ -43,6 +44,7 @@ const dataStatisticsMutation = {
 const App = ({
     location,
     visualization,
+    addMetadata,
     clearCurrent,
     clearVisualization,
     setCurrent,
@@ -98,6 +100,24 @@ const App = ({
         setPreviousLocation(location.pathname)
     }
 
+    const onResponseReceived = response => {
+        const metadata = Object.entries(response.metaData.items).reduce(
+            (obj, [id, item]) => {
+                obj[id] = {
+                    id,
+                    name: item.name || item.displayName,
+                    displayName: item.displayName,
+                    dimensionItemType: item.dimensionItemType, // TODO needed?
+                }
+
+                return obj
+            },
+            {}
+        )
+
+        addMetadata(metadata)
+    }
+
     useEffect(() => {
         setUser(d2.currentUser)
         loadVisualization(location)
@@ -146,7 +166,10 @@ const App = ({
                     >
                         {initialLoadIsComplete ? (
                             visualization ? (
-                                <Visualization visualization={visualization} />
+                                <Visualization
+                                    visualization={visualization}
+                                    onResponseReceived={onResponseReceived}
+                                />
                             ) : (
                                 <StartScreen />
                             )
@@ -168,6 +191,7 @@ const mapStateToProps = state => ({
 })
 
 const mapDispatchToProps = {
+    addMetadata: acAddMetadata,
     clearVisualization: acClearVisualization,
     clearCurrent: acClearCurrent,
     setCurrent: acSetCurrent,
@@ -176,6 +200,7 @@ const mapDispatchToProps = {
 }
 
 App.propTypes = {
+    addMetadata: PropTypes.func,
     clearCurrent: PropTypes.func,
     clearVisualization: PropTypes.func,
     location: PropTypes.object,


### PR DESCRIPTION
* store metadata from the analytics response in the store
* use item names instead of ids in the `DataTable`

The `DataTable` looks much better now:

<img width="1021" alt="Screenshot 2021-10-06 at 15 01 22" src="https://user-images.githubusercontent.com/150978/136207325-1cc397aa-a201-4d28-b3ae-97677b153c00.png">
