### PR TITLE
refactor: move the visualization query to a custom hook

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,4 @@
-import { useDataQuery, useDataMutation } from '@dhis2/app-runtime'
+import { useDataMutation } from '@dhis2/app-runtime'
 import { useD2 } from '@dhis2/app-runtime-adapter-d2'
 import { CssVariables } from '@dhis2/ui'
 import PropTypes from 'prop-types'
@@ -13,6 +13,7 @@ import {
 } from '../actions/visualization'
 import { EVENT_TYPE } from '../modules/dataStatistics'
 import history from '../modules/history'
+import { useVisualization } from '../modules/useVisualization'
 import { sGetCurrent } from '../reducers/current'
 import { sGetVisualization } from '../reducers/visualization'
 import classes from './App.module.css'
@@ -20,17 +21,6 @@ import { default as TitleBar } from './TitleBar/TitleBar'
 import { Toolbar } from './Toolbar/Toolbar'
 import StartScreen from './Visualization/StartScreen'
 import { Visualization } from './Visualization/Visualization'
-
-const visualizationQuery = {
-    eventReport: {
-        resource: 'eventReports',
-        id: ({ id }) => id,
-        // TODO check if this list is what we need/want (copied from old ER)
-        params: {
-            fields: '*,interpretations[*,user[id,displayName,userCredentials[username]],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName,userCredentials[username]]]],columns[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],rows[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],filters[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],program[id,displayName~rename(name),enrollmentDateLabel,incidentDateLabel],programStage[id,displayName~rename(name),executionDateLabel],access,userGroupAccesses,publicAccess,displayDescription,user[displayName,userCredentials[username]],href,!rewindRelativePeriods,!userOrganisationUnit,!userOrganisationUnitChildren,!userOrganisationUnitGrandChildren,!externalAccess,!relativePeriods,!columnDimensions,!rowDimensions,!filterDimensions,!organisationUnitGroups,!itemOrganisationUnitGroups,!indicators,!dataElements,!dataElementOperands,!dataElementGroups,!dataSets,!periods,!organisationUnitLevels,!organisationUnits,dataElementDimensions[legendSet[id,name],dataElement[id,name]]',
-        },
-    },
-}
 
 const dataStatisticsMutation = {
     resource: 'dataStatistics',
@@ -53,9 +43,7 @@ const App = ({
 }) => {
     const [previousLocation, setPreviousLocation] = useState(null)
     const [initialLoadIsComplete, setInitialLoadIsComplete] = useState(false)
-    const { data, refetch } = useDataQuery(visualizationQuery, {
-        lazy: true,
-    })
+    const { data, refetch } = useVisualization()
     const [postDataStatistics] = useDataMutation(dataStatisticsMutation)
     const { d2 } = useD2()
 
@@ -144,6 +132,7 @@ const App = ({
 
     useEffect(() => {
         const visualization = data?.eventReport
+
         if (visualization) {
             setVisualization(visualization)
             setCurrent(visualization)

--- a/src/modules/useVisualization.js
+++ b/src/modules/useVisualization.js
@@ -1,0 +1,18 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+
+const visualizationQuery = {
+    eventReport: {
+        resource: 'eventReports',
+        id: ({ id }) => id,
+        // TODO check if this list is what we need/want (copied from old ER)
+        params: {
+            fields: '*,interpretations[*,user[id,displayName,userCredentials[username]],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName,userCredentials[username]]]],columns[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],rows[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],filters[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,displayName~rename(name)]],program[id,displayName~rename(name),enrollmentDateLabel,incidentDateLabel],programStage[id,displayName~rename(name),executionDateLabel],access,userGroupAccesses,publicAccess,displayDescription,user[displayName,userCredentials[username]],href,!rewindRelativePeriods,!userOrganisationUnit,!userOrganisationUnitChildren,!userOrganisationUnitGrandChildren,!externalAccess,!relativePeriods,!columnDimensions,!rowDimensions,!filterDimensions,!organisationUnitGroups,!itemOrganisationUnitGroups,!indicators,!dataElements,!dataElementOperands,!dataElementGroups,!dataSets,!periods,!organisationUnitLevels,!organisationUnits,dataElementDimensions[legendSet[id,name],dataElement[id,name]]',
+        },
+    },
+}
+
+export const useVisualization = () => {
+    return useDataQuery(visualizationQuery, {
+        lazy: true,
+    })
+}


### PR DESCRIPTION
This is more of a test of how we can split the code when using
dataEngine/query.