### PR TITLE
chore: add the pr template from DV

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+Implements [DHIS2-XXXX](https://jira.dhis2.org/browse/DHIS2-XXXX)
+
+**Requires https://github.com/dhis2/analytics/pull/XXX**
+
+---
+
+### Key features
+
+1. _feature_
+
+---
+
+### Description
+
+_text_
+
+---
+
+### TODO
+
+-   [ ] _task_
+
+---
+
+### Known issues
+
+-   [ ] _issue_
+
+---
+
+### Screenshots
+
+_supporting text_


### PR DESCRIPTION
The template is already in `develop`, but it needs to go on the `master` branch for GH to pick it up

Copied from https://github.com/dhis2/event-reports-app/blob/develop/.github/pull_request_template.md