### PR TITLE
Chore/enable-deploy-previews-for-develop-branch

### DIFF
--- a/.github/workflows/dhis2-preview-pr.yml
+++ b/.github/workflows/dhis2-preview-pr.yml
@@ -47,6 +47,7 @@ jobs:
                   alias: pr-${{ github.event.number }}
                   # customize according to project needs
                   publish-dir: 'build/app'
+                  fails-without-credentials: true
               env:
                   # org secret
                   NETLIFY_AUTH_TOKEN: ${{ secrets.DHIS2_BOT_NETLIFY_TOKEN }}


### PR DESCRIPTION
Implements PR deploy previews for the develop branch

### Key features

Live previews

### Description

The primary purpose of this branch is to work out why the netlify deployments are not happening currently. 

If the outcome is that this is not happening due to a lack of credentials, they should be added and this PR can be closed.

If we find another problem, we will fix it in this branch.
