### PR TITLE
fix(visualization): make table auto-width + add relativePeriodDate prop

### DIFF
--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -52,11 +52,11 @@
     overflow-x: hidden;
 }
 
-/* Main center */
+/* Main canvas */
 
 .mainCenterCanvas {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     height: 100%;
     overflow: hidden;
     position: relative;

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -6,9 +6,9 @@ import {
     DataTableRow,
     DataTableCell,
     DataTableColumnHeader,
-    DataTableToolbar,
-    TableHead,
-    TableBody,
+    DataTableHead,
+    DataTableBody,
+    DataTableFoot,
     Pagination,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
@@ -34,7 +34,11 @@ const getFontSizeClass = fontSize => {
     }
 }
 
-export const Visualization = ({ visualization, onResponseReceived }) => {
+export const Visualization = ({
+    visualization,
+    onResponseReceived,
+    relativePeriodDate,
+}) => {
     const dataEngine = useDataEngine()
     const [analyticsResponse, setAnalyticsResponse] = useState(null)
     const [headers, setHeaders] = useState([])
@@ -52,6 +56,11 @@ export const Visualization = ({ visualization, onResponseReceived }) => {
     // analytics
     const fetchAnalyticsData = useCallback(async () => {
         const analyticsEngine = Analytics.getAnalytics(dataEngine)
+        const params = { completedOnly: visualization.completedOnly }
+
+        if (relativePeriodDate) {
+            params.relativePeriodDate = relativePeriodDate
+        }
 
         const req = new analyticsEngine.request()
             .fromVisualization(visualization)
@@ -59,7 +68,7 @@ export const Visualization = ({ visualization, onResponseReceived }) => {
             .withStage(visualization.programStage.id)
             .withDisplayProperty('NAME') // TODO from settings ?!
             .withOutputType(visualization.outputType)
-            .withParameters({ completedOnly: visualization.completedOnly })
+            .withParameters(params)
             .withPageSize(pageSize)
             .withPage(page)
 
@@ -89,7 +98,14 @@ export const Visualization = ({ visualization, onResponseReceived }) => {
         }
 
         doFetch()
-    }, [visualization, page, pageSize, sortField, sortDirection])
+    }, [
+        visualization,
+        page,
+        pageSize,
+        sortField,
+        sortDirection,
+        relativePeriodDate,
+    ])
 
     useEffect(() => {
         if (analyticsResponse) {
@@ -139,10 +155,12 @@ export const Visualization = ({ visualization, onResponseReceived }) => {
 
     const fontSizeClass = getFontSizeClass(visualization.fontSize)
 
+    const colSpan = String(Math.max(headers.length, 1))
+
     return (
         <div className={styles.wrapper}>
-            <DataTable scrollHeight="500px" scrollWidth="1000px" width="1000px">
-                <TableHead>
+            <DataTable scrollHeight="500px" width="auto">
+                <DataTableHead>
                     <DataTableRow>
                         {headers.map((header, index) =>
                             header ? (
@@ -178,8 +196,8 @@ export const Visualization = ({ visualization, onResponseReceived }) => {
                             )
                         )}
                     </DataTableRow>
-                </TableHead>
-                <TableBody>
+                </DataTableHead>
+                <DataTableBody>
                     {rows.map((row, index) => (
                         <DataTableRow key={index}>
                             {row.map((value, index) => (
@@ -194,38 +212,46 @@ export const Visualization = ({ visualization, onResponseReceived }) => {
                             ))}
                         </DataTableRow>
                     ))}
-                </TableBody>
-            </DataTable>
-            <DataTableToolbar position="bottom">
-                <div className={styles.paginationControls}>
-                    <Pagination
-                        page={page}
-                        pageCount={analyticsResponse.metaData.pager.pageCount}
-                        pageSize={pageSize}
-                        total={analyticsResponse.metaData.pager.total}
-                        onPageChange={setPage}
-                        onPageSizeChange={setPageSize}
-                        pageSizeSelectText={i18n.t('Cases per page')}
-                        pageSummaryText={({ firstItem, lastItem, total }) =>
-                            i18n.t(
-                                '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
-                                {
-                                    firstCaseIndex: firstItem,
-                                    lastCaseIndex: lastItem,
-                                    count: total,
-                                    // FIXME does it make sense if there is only 1 case?! "1 of 1 case"
-                                    // not sure is possible to have empty string for singular with i18n
-                                    // TODO also, this string for some reason is not extracted
-                                    defaultValue:
-                                        '{{firstCaseIndex}} of {{count}} case',
-                                    defaultValue_plural:
-                                        '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                </DataTableBody>
+                <DataTableFoot className={styles.stickyFooter}>
+                    <DataTableRow>
+                        <DataTableCell colSpan={colSpan} staticStyle>
+                            <Pagination
+                                page={page}
+                                pageCount={
+                                    analyticsResponse.metaData.pager.pageCount
                                 }
-                            )
-                        }
-                    />
-                </div>
-            </DataTableToolbar>
+                                pageSize={pageSize}
+                                total={analyticsResponse.metaData.pager.total}
+                                onPageChange={setPage}
+                                onPageSizeChange={setPageSize}
+                                pageSizeSelectText={i18n.t('Cases per page')}
+                                pageSummaryText={({
+                                    firstItem,
+                                    lastItem,
+                                    total,
+                                }) =>
+                                    i18n.t(
+                                        '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                                        {
+                                            firstCaseIndex: firstItem,
+                                            lastCaseIndex: lastItem,
+                                            count: total,
+                                            // FIXME does it make sense if there is only 1 case?! "1 of 1 case"
+                                            // not sure is possible to have empty string for singular with i18n
+                                            // TODO also, this string for some reason is not extracted
+                                            defaultValue:
+                                                '{{firstCaseIndex}} of {{count}} case',
+                                            defaultValue_plural:
+                                                '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                                        }
+                                    )
+                                }
+                            />
+                        </DataTableCell>
+                    </DataTableRow>
+                </DataTableFoot>
+            </DataTable>
         </div>
     )
 }
@@ -236,5 +262,6 @@ Visualization.defaultProps = {
 
 Visualization.propTypes = {
     visualization: PropTypes.object.isRequired,
-    onResponseReceived: PropTypes.func,
+    onResponseReceived: PropTypes.func.isRequired,
+    relativePeriodDate: PropTypes.string,
 }

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -56,21 +56,19 @@ export const Visualization = ({
     // analytics
     const fetchAnalyticsData = useCallback(async () => {
         const analyticsEngine = Analytics.getAnalytics(dataEngine)
-        const params = { completedOnly: visualization.completedOnly }
-
-        if (relativePeriodDate) {
-            params.relativePeriodDate = relativePeriodDate
-        }
-
         const req = new analyticsEngine.request()
             .fromVisualization(visualization)
             .withProgram(visualization.program.id)
             .withStage(visualization.programStage.id)
             .withDisplayProperty('NAME') // TODO from settings ?!
             .withOutputType(visualization.outputType)
-            .withParameters(params)
+            .withParameters({ completedOnly: visualization.completedOnly })
             .withPageSize(pageSize)
             .withPage(page)
+
+        if (relativePeriodDate) {
+            req.withRelativePeriodDate(relativePeriodDate)
+        }
 
         if (sortField) {
             switch (sortDirection) {

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -1,13 +1,14 @@
 .wrapper {
     display: flex;
-    flex-direction: column;
-    flex-grow: 1;
+    flex-direction: row;
+    flex-grow: 0;
+    align-items: flex-start;
 }
 
-.paginationControls {
-    width: 100%;
-    display: flex;
-    justify-content: flex-end;
+.stickyFooter {
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
 }
 
 .fontSizeLarge {


### PR DESCRIPTION
### Key features

1. Makes the data-table have an automatic layout/width
2. Adds the relativePeriodDate prop

---

### Description

The datatable is now horizontally centered and has an automtic width. The auto-width feature is visible in the specs and I know from other apps I've recently worked on that this is a required functionality. However,if we want to keep showing the TitleBar before the datatable is ready, and the keep it seperate from the datatable, we can't left align the table and center-align the title above it. So in the end we need to decide between two options:
A. Put the title into the table, and accept this isn’t rendered when the table is loading. (we would have to find some way to not render the title when in a plugin)
B. Center the table and title as in the screenshot.

---

### TODO

-   [ ] Check with Joe about the best solution

---

### Known issues

-   [ ] Showing things in the horizontal center is not inline with the design specs

---

### Screenshots
<img width="1479" alt="Screenshot 2021-11-03 at 11 42 27" src="https://user-images.githubusercontent.com/353236/140057124-01334c31-2d96-4a84-b4b7-7301ab8d24e2.png">

