### PR TITLE
fix: remove onClick handler for disabled types in vis type selector

### DIFF
--- a/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeSelector.js
+++ b/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeSelector.js
@@ -19,17 +19,21 @@ export const VisualizationTypeSelector = ({ visualizationType }) => {
 
     const getVisTypes = () => Object.keys(visTypeMap).sort()
 
-    const renderVisualizationTypeListItem = type => (
-        <VisualizationTypeListItem
-            key={type}
-            visType={type}
-            label={visTypeMap[type].name}
-            description={visTypeMap[type].description}
-            isSelected={type === visualizationType}
-            onClick={handleListItemClick(type)}
-            disabled={visTypeMap[type].disabled}
-        />
-    )
+    const renderVisualizationTypeListItem = type => {
+        const isDisabled = visTypeMap[type].disabled
+
+        return (
+            <VisualizationTypeListItem
+                key={type}
+                visType={type}
+                label={visTypeMap[type].name}
+                description={visTypeMap[type].description}
+                isSelected={type === visualizationType}
+                onClick={isDisabled ? null : handleListItemClick(type)}
+                disabled={isDisabled}
+            />
+        )
+    }
 
     const VisTypesList = (
         <Card dataTest={'visualization-type-selector-card'}>


### PR DESCRIPTION
### Key features

1. remove the onClick handler for the disabled types in the visualization type selector

---

### Description

Nothing should happen when a disabled item is clicked in the visualization type selector.