### PR TITLE
TECH-825-modal-open-content-shift

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-01T12:53:09.293Z\n"
-"PO-Revision-Date: 2021-12-01T12:53:09.293Z\n"
+"POT-Creation-Date: 2021-12-06T15:51:12.920Z\n"
+"PO-Revision-Date: 2021-12-06T15:51:12.920Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -205,6 +205,16 @@ msgstr "TEXT"
 
 msgid "Your most viewed TEXT"
 msgstr "Your most viewed TEXT"
+
+msgid "Could not load visualization"
+msgstr "Could not load visualization"
+
+msgid ""
+"The visualization couldn’t be displayed. Try again or contact your system "
+"administrator."
+msgstr ""
+"The visualization couldn’t be displayed. Try again or contact your system "
+"administrator."
 
 msgid "Cases per page"
 msgstr "Cases per page"

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -174,15 +174,16 @@ const App = ({
             const isSaving = location.state?.isSaving
             const isOpening = location.state?.isOpening
             const isResetting = location.state?.isResetting
+            const isModalOpening = location.state?.isModalOpening
+            const isModalClosing = location.state?.isModalClosing
+            const isValidLocationChange =
+                previousLocation !== location.pathname &&
+                !isModalOpening &&
+                !isModalClosing
 
             // TODO navigation confirm dialog
 
-            if (
-                isSaving ||
-                isOpening ||
-                isResetting ||
-                previousLocation !== location.pathname
-            ) {
+            if (isSaving || isOpening || isResetting || isValidLocationChange) {
                 loadVisualization(location)
             }
         })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -92,7 +92,7 @@ const App = ({
         interpretationsUnitRef.current.refresh()
     }
 
-    const needsRefetch = (location) => {
+    const needsRefetch = location => {
         if (!previousLocation) {
             return true
         }
@@ -107,14 +107,14 @@ const App = ({
         return false
     }
 
-    const parseLocation = (location) => {
+    const parseLocation = location => {
         const pathParts = location.pathname.slice(1).split('/')
         const id = pathParts[0]
         const interpretationId = pathParts[2]
         return { id, interpretationId }
     }
 
-    const loadVisualization = (location) => {
+    const loadVisualization = location => {
         setVisualizationLoading(true)
         if (location.pathname.length > 1) {
             // /currentAnalyticalObject
@@ -137,7 +137,7 @@ const App = ({
         setPreviousLocation(location.pathname)
     }
 
-    const onResponseReceived = (response) => {
+    const onResponseReceived = response => {
         setVisualizationLoading(false)
         const metadata = Object.entries(response.metaData.items).reduce(
             (obj, [id, item]) => {
@@ -272,9 +272,6 @@ const App = ({
                                                 onInterpretationUpdate={
                                                     onInterpretationUpdate
                                                 }
-                                                onResponseReceived={
-                                                    onResponseReceived
-                                                }
                                             />
                                         )}
                                     </>
@@ -295,7 +292,7 @@ const App = ({
     )
 }
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
     current: sGetCurrent(state),
     isLoading: sGetIsVisualizationLoading(state),
     showRightSidebar: sGetUiShowRightSidebar(state),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -92,7 +92,7 @@ const App = ({
         interpretationsUnitRef.current.refresh()
     }
 
-    const needsRefetch = location => {
+    const needsRefetch = (location) => {
         if (!previousLocation) {
             return true
         }
@@ -107,14 +107,14 @@ const App = ({
         return false
     }
 
-    const parseLocation = location => {
+    const parseLocation = (location) => {
         const pathParts = location.pathname.slice(1).split('/')
         const id = pathParts[0]
         const interpretationId = pathParts[2]
         return { id, interpretationId }
     }
 
-    const loadVisualization = location => {
+    const loadVisualization = (location) => {
         setVisualizationLoading(true)
         if (location.pathname.length > 1) {
             // /currentAnalyticalObject
@@ -137,7 +137,7 @@ const App = ({
         setPreviousLocation(location.pathname)
     }
 
-    const onResponseReceived = response => {
+    const onResponseReceived = (response) => {
         setVisualizationLoading(false)
         const metadata = Object.entries(response.metaData.items).reduce(
             (obj, [id, item]) => {
@@ -292,7 +292,7 @@ const App = ({
     )
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state) => ({
     current: sGetCurrent(state),
     isLoading: sGetIsVisualizationLoading(state),
     showRightSidebar: sGetUiShowRightSidebar(state),

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -268,7 +268,6 @@ const App = ({
                                         )}
                                         {current && (
                                             <InterpretationModal
-                                                visualization={current}
                                                 onInterpretationUpdate={
                                                     onInterpretationUpdate
                                                 }

--- a/src/components/DetailsPanel/DetailsPanel.js
+++ b/src/components/DetailsPanel/DetailsPanel.js
@@ -1,5 +1,6 @@
 import { AboutAOUnit } from '@dhis2/analytics'
 import PropTypes from 'prop-types'
+import { stringify } from 'query-string'
 import React from 'react'
 import { connect } from 'react-redux'
 import history from '../../modules/history.js'
@@ -7,6 +8,16 @@ import { sGetCurrent } from '../../reducers/current.js'
 import { sGetUser } from '../../reducers/user.js'
 import { InterpretationsUnit } from '../Interpretations/InterpretationsUnit/index.js'
 import classes from './styles/DetailsPanel.module.css'
+
+const navigateToOpenModal = (interpretationId, initialFocus) => {
+    history.push(
+        {
+            pathName: history.location.pathname,
+            search: `?${stringify({ interpretationId, initialFocus })}`,
+        },
+        { isModalOpening: true }
+    )
+}
 
 export const DetailsPanel = ({
     currentUser,
@@ -21,14 +32,10 @@ export const DetailsPanel = ({
             id={visualization.id}
             currentUser={currentUser}
             onInterpretationClick={(interpretationId) =>
-                history.push(
-                    `/${visualization.id}?interpretationId=${interpretationId}`
-                )
+                navigateToOpenModal(interpretationId)
             }
             onReplyIconClick={(interpretationId) =>
-                history.push(
-                    `/${visualization.id}?interpretationId=${interpretationId}&initialFocus=true`
-                )
+                navigateToOpenModal(interpretationId, true)
             }
         />
     </div>

--- a/src/components/InterpretationModal/InterpretationModal.js
+++ b/src/components/InterpretationModal/InterpretationModal.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
-import React from 'react'
-import { useSelector } from 'react-redux'
+import React, { useState, useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { acSetVisualizationLoading } from '../../actions/loader.js'
 import { ModalDownloadDropdown } from '../DownloadMenu/index.js'
 import { InterpretationModal as AnalyticsInterpretationModal } from '../Interpretations/InterpretationModal/index.js'
 import {
@@ -8,38 +9,39 @@ import {
     removeInterpretationQueryParams,
 } from './interpretationIdQueryParam.js'
 
-const InterpretationModal = ({
-    visualization,
-    onResponseReceived,
-    onInterpretationUpdate,
-}) => {
+const InterpretationModal = ({ visualization, onInterpretationUpdate }) => {
     const { interpretationId, initialFocus } = useInterpretationQueryParams()
-    const isVisualizationLoading = useSelector(
-        (state) => state.loader.isVisualizationLoading
-    )
+    const [isVisualizationLoading, setIsVisualizationLoading] = useState(false)
     const currentUser = useSelector((state) => state.user)
+    const dispatch = useDispatch()
 
-    if (!interpretationId) {
-        return null
+    const onClose = () => {
+        removeInterpretationQueryParams()
+        dispatch(acSetVisualizationLoading(false))
     }
 
-    return (
+    useEffect(() => {
+        setIsVisualizationLoading(!!interpretationId)
+    }, [interpretationId])
+
+    return interpretationId ? (
         <AnalyticsInterpretationModal
             currentUser={currentUser}
             onInterpretationUpdate={onInterpretationUpdate}
             initialFocus={initialFocus}
             interpretationId={interpretationId}
             isVisualizationLoading={isVisualizationLoading}
-            onClose={removeInterpretationQueryParams}
-            onResponseReceived={onResponseReceived}
+            onClose={onClose}
+            onResponseReceived={() => setIsVisualizationLoading(false)}
             visualization={visualization}
             downloadMenuComponent={ModalDownloadDropdown}
         />
-    )
+    ) : null
 }
+
 InterpretationModal.propTypes = {
     visualization: PropTypes.object.isRequired,
     onInterpretationUpdate: PropTypes.func.isRequired,
-    onResponseReceived: PropTypes.func,
 }
+
 export { InterpretationModal }

--- a/src/components/InterpretationModal/InterpretationModal.js
+++ b/src/components/InterpretationModal/InterpretationModal.js
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { acSetVisualizationLoading } from '../../actions/loader.js'
+import { sGetCurrent } from '../../reducers/current.js'
+import { sGetUser } from '../../reducers/user.js'
 import { ModalDownloadDropdown } from '../DownloadMenu/index.js'
 import { InterpretationModal as AnalyticsInterpretationModal } from '../Interpretations/InterpretationModal/index.js'
 import {
@@ -9,10 +11,11 @@ import {
     removeInterpretationQueryParams,
 } from './interpretationIdQueryParam.js'
 
-const InterpretationModal = ({ visualization, onInterpretationUpdate }) => {
+const InterpretationModal = ({ onInterpretationUpdate }) => {
     const { interpretationId, initialFocus } = useInterpretationQueryParams()
     const [isVisualizationLoading, setIsVisualizationLoading] = useState(false)
-    const currentUser = useSelector((state) => state.user)
+    const visualization = useSelector(sGetCurrent)
+    const currentUser = useSelector(sGetUser)
     const dispatch = useDispatch()
 
     const onClose = () => {
@@ -40,7 +43,6 @@ const InterpretationModal = ({ visualization, onInterpretationUpdate }) => {
 }
 
 InterpretationModal.propTypes = {
-    visualization: PropTypes.object.isRequired,
     onInterpretationUpdate: PropTypes.func.isRequired,
 }
 

--- a/src/components/InterpretationModal/InterpretationModal.js
+++ b/src/components/InterpretationModal/InterpretationModal.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
-import { useSelector, useDispatch } from 'react-redux'
-import { acSetVisualizationLoading } from '../../actions/loader.js'
+import { useSelector } from 'react-redux'
 import { sGetCurrent } from '../../reducers/current.js'
 import { sGetUser } from '../../reducers/user.js'
 import { ModalDownloadDropdown } from '../DownloadMenu/index.js'
@@ -16,12 +15,6 @@ const InterpretationModal = ({ onInterpretationUpdate }) => {
     const [isVisualizationLoading, setIsVisualizationLoading] = useState(false)
     const visualization = useSelector(sGetCurrent)
     const currentUser = useSelector(sGetUser)
-    const dispatch = useDispatch()
-
-    const onClose = () => {
-        removeInterpretationQueryParams()
-        dispatch(acSetVisualizationLoading(false))
-    }
 
     useEffect(() => {
         setIsVisualizationLoading(!!interpretationId)
@@ -34,7 +27,7 @@ const InterpretationModal = ({ onInterpretationUpdate }) => {
             initialFocus={initialFocus}
             interpretationId={interpretationId}
             isVisualizationLoading={isVisualizationLoading}
-            onClose={onClose}
+            onClose={removeInterpretationQueryParams}
             onResponseReceived={() => setIsVisualizationLoading(false)}
             visualization={visualization}
             downloadMenuComponent={ModalDownloadDropdown}

--- a/src/components/InterpretationModal/interpretationIdQueryParam.js
+++ b/src/components/InterpretationModal/interpretationIdQueryParam.js
@@ -1,15 +1,26 @@
 import { parse, stringify } from 'query-string'
+import { useState, useEffect } from 'react'
 import history from '../../modules/history.js'
 
 const options = { parseBooleans: true }
 
 const useInterpretationQueryParams = () => {
-    const { interpretationId, initialFocus } = parse(
-        history.location.search,
-        options
+    const [params, setParams] = useState(
+        parse(history.location.search, options)
     )
+    useEffect(() => {
+        const unlisten = history.listen(({ location }) => {
+            if (location.state?.isModalOpening) {
+                setParams(parse(history.location.search, options))
+            }
+            if (location.state?.isModalClosing) {
+                setParams(parse(history.location.search, options))
+            }
+        })
+        return unlisten
+    }, [])
 
-    return { interpretationId, initialFocus }
+    return params
 }
 
 const removeInterpretationQueryParams = () => {
@@ -26,10 +37,15 @@ const removeInterpretationQueryParams = () => {
     )
     const search = stringify(parsedWithoutInterpretationId)
 
-    history.push({
-        ...history.location,
-        search,
-    })
+    history.push(
+        {
+            ...history.location,
+            search,
+        },
+        {
+            isModalClosing: true,
+        }
+    )
 }
 
 export { useInterpretationQueryParams, removeInterpretationQueryParams }

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -8,6 +8,9 @@ import {
     Button,
     spacers,
     colors,
+    Layer,
+    CenteredContent,
+    CircularLoader,
 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -93,108 +96,122 @@ const InterpretationModal = ({
     }, [interpretationId])
 
     return (
-        <Modal
-            onClose={handleClose}
-            className={cx(modalCSS.className, {
-                hidden: shouldCssHideModal,
-            })}
-        >
-            <h1 className="title">
-                <span className="ellipsis">
-                    {i18n.t('Viewing interpretation: {{visualisationName}}', {
-                        visualisationName: visualization.displayName,
-                        nsSeparator: '^^',
-                    })}
-                </span>
-            </h1>
-            <ModalContent className="modalContent">
-                <div className="container">
-                    {error && (
-                        <NoticeBox
-                            error
-                            title={i18n.t('Could not load interpretation')}
-                        >
-                            {error.message ||
-                                i18n.t(
-                                    'The interpretation couldn’t be displayed. Try again or contact your system administrator.'
-                                )}
-                        </NoticeBox>
-                    )}
-                    {shouldRenderModalContent && (
-                        <div className="row">
-                            <div className="visualisation-wrap">
-                                <Visualization
-                                    relativePeriodDate={interpretation.created}
-                                    visualization={visualization}
-                                    onResponseReceived={onResponseReceived}
-                                />
+        <>
+            {shouldCssHideModal && (
+                <Layer>
+                    <CenteredContent>
+                        <CircularLoader />
+                    </CenteredContent>
+                </Layer>
+            )}
+            <Modal
+                onClose={handleClose}
+                className={cx(modalCSS.className, {
+                    hidden: shouldCssHideModal,
+                })}
+            >
+                <h1 className="title">
+                    <span className="ellipsis">
+                        {i18n.t(
+                            'Viewing interpretation: {{visualisationName}}',
+                            {
+                                visualisationName: visualization.displayName,
+                                nsSeparator: '^^',
+                            }
+                        )}
+                    </span>
+                </h1>
+                <ModalContent className="modalContent">
+                    <div className="container">
+                        {error && (
+                            <NoticeBox
+                                error
+                                title={i18n.t('Could not load interpretation')}
+                            >
+                                {error.message ||
+                                    i18n.t(
+                                        'The interpretation couldn’t be displayed. Try again or contact your system administrator.'
+                                    )}
+                            </NoticeBox>
+                        )}
+                        {shouldRenderModalContent && (
+                            <div className="row">
+                                <div className="visualisation-wrap">
+                                    <Visualization
+                                        relativePeriodDate={
+                                            interpretation.created
+                                        }
+                                        visualization={visualization}
+                                        onResponseReceived={onResponseReceived}
+                                    />
+                                </div>
+                                <div className="thread-wrap">
+                                    <InterpretationThread
+                                        currentUser={currentUser}
+                                        fetching={fetching}
+                                        interpretation={interpretation}
+                                        onInterpretationDeleted={
+                                            onInterpretationDeleted
+                                        }
+                                        onThreadUpdated={onThreadUpdated}
+                                        initialFocus={initialFocus}
+                                        downloadMenuComponent={
+                                            downloadMenuComponent
+                                        }
+                                    />
+                                </div>
                             </div>
-                            <div className="thread-wrap">
-                                <InterpretationThread
-                                    currentUser={currentUser}
-                                    fetching={fetching}
-                                    interpretation={interpretation}
-                                    onInterpretationDeleted={
-                                        onInterpretationDeleted
-                                    }
-                                    onThreadUpdated={onThreadUpdated}
-                                    initialFocus={initialFocus}
-                                    downloadMenuComponent={
-                                        downloadMenuComponent
-                                    }
-                                />
-                            </div>
-                        </div>
-                    )}
-                </div>
-            </ModalContent>
-            <ModalActions>
-                <Button disabled={fetching} onClick={handleClose}>
-                    {i18n.t('Hide interpretation')}
-                </Button>
-            </ModalActions>
-            {modalCSS.styles}
-            <style jsx>{`
-                .title {
-                    color: ${colors.grey900};
-                    font-size: 20px;
-                    font-weight: 500;
-                    line-height: 24px;
-                    margin: 0px;
-                    padding: ${spacers.dp24} ${spacers.dp24} 0;
-                }
+                        )}
+                    </div>
+                </ModalContent>
+                <ModalActions>
+                    <Button disabled={fetching} onClick={handleClose}>
+                        {i18n.t('Hide interpretation')}
+                    </Button>
+                </ModalActions>
+                {modalCSS.styles}
+                <style jsx>{`
+                    .title {
+                        color: ${colors.grey900};
+                        font-size: 20px;
+                        font-weight: 500;
+                        line-height: 24px;
+                        margin: 0px;
+                        padding: ${spacers.dp24} ${spacers.dp24} 0;
+                    }
 
-                .ellipsis {
-                    display: inline-block;
-                    line-height: 20px;
-                    white-space: nowrap;
-                    width: 100%;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                }
+                    .ellipsis {
+                        display: inline-block;
+                        line-height: 20px;
+                        white-space: nowrap;
+                        width: 100%;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                    }
 
-                .container {
-                    display: flex;
-                    flex-direction: column;
-                }
+                    .container {
+                        display: flex;
+                        flex-direction: column;
+                    }
 
-                .row {
-                    display: flex;
-                    flex-direction: row;
-                    gap: 16px;
-                }
+                    .row {
+                        display: flex;
+                        flex-direction: row;
+                        gap: 16px;
+                    }
 
-                .visualisation-wrap {
-                    flex-grow: 1;
-                }
+                    .visualisation-wrap {
+                        flex-grow: 1;
+                    }
 
-                .thread-wrap {
-                    flex-basis: 300px;
-                    flex-shrink: 0;
-                    overflow-y: auto;
-                }
-            `}</style>
-        </Modal>
+                    .thread-wrap {
+                        flex-basis: 300px;
+                        flex-shrink: 0;
+                        overflow-y: auto;
+                    }
+                `}</style>
+            </Modal>
+        </>
     )
 }
 

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -94,7 +94,6 @@ const InterpretationModal = ({
 
     return (
         <Modal
-            position="middle"
             onClose={handleClose}
             className={cx(modalCSS.className, {
                 hidden: shouldCssHideModal,

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -92,15 +92,6 @@ const InterpretationModal = ({
         }
     }, [interpretationId])
 
-    console.log(
-        '++++ InterpretationModal ++++',
-        '\nloading: ',
-        loading,
-        '\nisVisualizationLoading: ',
-        isVisualizationLoading,
-        '\n---------------'
-    )
-
     return (
         <Modal
             onClose={handleClose}

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -74,7 +74,7 @@ const InterpretationModal = ({
         }
         onClose()
     }
-    const onThreadUpdated = affectsInterpretation => {
+    const onThreadUpdated = (affectsInterpretation) => {
         if (affectsInterpretation) {
             setIsDirty(true)
         }

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -74,7 +74,7 @@ const InterpretationModal = ({
         }
         onClose()
     }
-    const onThreadUpdated = (affectsInterpretation) => {
+    const onThreadUpdated = affectsInterpretation => {
         if (affectsInterpretation) {
             setIsDirty(true)
         }
@@ -91,6 +91,15 @@ const InterpretationModal = ({
             refetch({ id: interpretationId })
         }
     }, [interpretationId])
+
+    console.log(
+        '++++ InterpretationModal ++++',
+        '\nloading: ',
+        loading,
+        '\nisVisualizationLoading: ',
+        isVisualizationLoading,
+        '\n---------------'
+    )
 
     return (
         <Modal

--- a/src/components/Interpretations/common/Interpretation/Interpretation.js
+++ b/src/components/Interpretations/common/Interpretation/Interpretation.js
@@ -70,7 +70,14 @@ export const Interpretation = ({
                 )}
             </MessageStatsBar>
             {!!onClick && (
-                <Button secondary small onClick={onClick}>
+                <Button
+                    secondary
+                    small
+                    onClick={(_, event) => {
+                        event.stopPropagation()
+                        onClick(interpretation.id)
+                    }}
+                >
                     {i18n.t('See interpretation')}
                 </Button>
             )}

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -70,8 +70,8 @@ export const Visualization = ({
 
     console.log(
         '++++ Visualization ++++',
-        '\ndata: ',
-        data,
+        '\nhasData: ',
+        !!data,
         '\nloading: ',
         loading,
         '\nfetching: ',

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -45,7 +45,7 @@ export const Visualization = ({
     })
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(100)
-    const { loading, fetching, error, data } = useAnalyticsData({
+    const { fetching, error, data } = useAnalyticsData({
         visualization,
         relativePeriodDate,
         onResponseReceived,
@@ -67,19 +67,6 @@ export const Visualization = ({
             </div>
         )
     }
-
-    console.log(
-        '++++ Visualization ++++',
-        '\nhasData: ',
-        !!data,
-        '\nloading: ',
-        loading,
-        '\nfetching: ',
-        fetching,
-        '\ninModal: ',
-        !!relativePeriodDate,
-        '\n------------'
-    )
 
     if (!data) {
         return (

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -69,17 +69,7 @@ export const Visualization = ({
     }
 
     if (!data) {
-        return (
-            <div
-                style={{
-                    width: 600,
-                    height: 400,
-                    backgroundColor: 'red',
-                }}
-            >
-                Should not be seen in the modal!
-            </div>
-        )
+        return null
     }
 
     const large = visualization.displayDensity === DISPLAY_DENSITY_COMFORTABLE

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -76,6 +76,8 @@ export const Visualization = ({
         loading,
         '\nfetching: ',
         fetching,
+        '\ninModal: ',
+        !!relativePeriodDate,
         '\n------------'
     )
 

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -22,7 +22,7 @@ import {
 import styles from './styles/Visualization.module.css'
 import { useAnalyticsData } from './useAnalyticsData.js'
 
-const getFontSizeClass = (fontSize) => {
+const getFontSizeClass = fontSize => {
     switch (fontSize) {
         case FONT_SIZE_LARGE:
             return styles.fontSizeLarge
@@ -45,7 +45,7 @@ export const Visualization = ({
     })
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(100)
-    const { fetching, error, data } = useAnalyticsData({
+    const { loading, fetching, error, data } = useAnalyticsData({
         visualization,
         relativePeriodDate,
         onResponseReceived,
@@ -68,8 +68,29 @@ export const Visualization = ({
         )
     }
 
+    console.log(
+        '++++ Visualization ++++',
+        '\ndata: ',
+        data,
+        '\nloading: ',
+        loading,
+        '\nfetching: ',
+        fetching,
+        '\n------------'
+    )
+
     if (!data) {
-        return null
+        return (
+            <div
+                style={{
+                    width: 600,
+                    height: 400,
+                    backgroundColor: 'red',
+                }}
+            >
+                Should not be seen in the modal!
+            </div>
+        )
     }
 
     const large = visualization.displayDensity === DISPLAY_DENSITY_COMFORTABLE

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -20,9 +20,9 @@ import {
     FONT_SIZE_SMALL,
 } from '../../modules/options.js'
 import styles from './styles/Visualization.module.css'
-import { useAnalyticsData } from './useAnalyticsData'
+import { useAnalyticsData } from './useAnalyticsData.js'
 
-const getFontSizeClass = fontSize => {
+const getFontSizeClass = (fontSize) => {
     switch (fontSize) {
         case FONT_SIZE_LARGE:
             return styles.fontSizeLarge

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -22,7 +22,7 @@ import {
 import styles from './styles/Visualization.module.css'
 import { useAnalyticsData } from './useAnalyticsData.js'
 
-const getFontSizeClass = fontSize => {
+const getFontSizeClass = (fontSize) => {
     switch (fontSize) {
         case FONT_SIZE_LARGE:
             return styles.fontSizeLarge

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -22,3 +22,8 @@
 .fontSizeSmall {
     font-size: 10px !important;
 }
+.error {
+    flex: 1;
+    align-self: flex-start;
+    margin: 0 var(--spacers-dp12);
+}

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -110,7 +110,6 @@ const useAnalyticsData = ({
 
                 mounted.current && setError(undefined)
                 mounted.current && setData({ headers, rows, pageCount, total })
-
                 onResponseReceived(analyticsResponse)
             } catch (error) {
                 mounted.current && setError(error)

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -11,7 +11,7 @@ const fetchAnalyticsData = async ({
     sortField,
     sortDirection,
 }) => {
-    const req = new analyticsEngine.request()
+    let req = new analyticsEngine.request()
         .fromVisualization(visualization)
         .withProgram(visualization.program.id)
         .withStage(visualization.programStage.id)
@@ -22,16 +22,16 @@ const fetchAnalyticsData = async ({
         .withPage(page)
 
     if (relativePeriodDate) {
-        req.withRelativePeriodDate(relativePeriodDate)
+        req = req.withRelativePeriodDate(relativePeriodDate)
     }
 
     if (sortField) {
         switch (sortDirection) {
             case 'asc':
-                req.withAsc(sortField)
+                req = req.withAsc(sortField)
                 break
             case 'desc':
-                req.withDesc(sortField)
+                req = req.withDesc(sortField)
                 break
         }
     }

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -1,0 +1,147 @@
+import { Analytics } from '@dhis2/analytics'
+import { useDataEngine } from '@dhis2/app-runtime'
+import { useEffect, useState, useRef } from 'react'
+
+const fetchAnalyticsData = async ({
+    analyticsEngine,
+    visualization,
+    pageSize,
+    page,
+    relativePeriodDate,
+    sortField,
+    sortDirection,
+}) => {
+    const req = new analyticsEngine.request()
+        .fromVisualization(visualization)
+        .withProgram(visualization.program.id)
+        .withStage(visualization.programStage.id)
+        .withDisplayProperty('NAME') // TODO from settings ?!
+        .withOutputType(visualization.outputType)
+        .withParameters({ completedOnly: visualization.completedOnly })
+        .withPageSize(pageSize)
+        .withPage(page)
+
+    if (relativePeriodDate) {
+        req.withRelativePeriodDate(relativePeriodDate)
+    }
+
+    if (sortField) {
+        switch (sortDirection) {
+            case 'asc':
+                req.withAsc(sortField)
+                break
+            case 'desc':
+                req.withDesc(sortField)
+                break
+        }
+    }
+
+    const rawResponse = await analyticsEngine.events.getQuery(req)
+
+    return new analyticsEngine.response(rawResponse)
+}
+
+const reduceHeaders = (analyticsResponse, visualization) =>
+    visualization.columns.reduce((headers, column) => {
+        headers.push(analyticsResponse.getHeader(column.dimension)) // TODO figure out what to do when no header match the column (ie. pe)
+        return headers
+    }, [])
+
+const reduceRows = (analyticsResponse, headers) =>
+    analyticsResponse.rows.reduce((filteredRows, row) => {
+        filteredRows.push(
+            headers.reduce((filteredRow, header) => {
+                if (header) {
+                    const rowValue = row[header.index]
+                    const itemKey = header.isPrefix
+                        ? `${header.name}_${rowValue}` // TODO underscore or space? check in AnalyticsResponse
+                        : rowValue
+
+                    filteredRow.push(
+                        analyticsResponse.metaData.items[itemKey]?.name ||
+                            rowValue
+                    )
+                } else {
+                    // FIXME solve the case of visualization.column not mapping to any response.header (ie. "pe")
+                    filteredRow.push('-')
+                }
+                return filteredRow
+            }, [])
+        )
+        return filteredRows
+    }, [])
+
+const useAnalyticsData = ({
+    visualization,
+    relativePeriodDate,
+    onResponseReceived,
+    sortField,
+    sortDirection,
+    page,
+    pageSize,
+}) => {
+    const dataEngine = useDataEngine()
+    const [analyticsEngine] = useState(() => Analytics.getAnalytics(dataEngine))
+    const mounted = useRef(false)
+    const [loading, setLoading] = useState(true)
+    const [fetching, setFetching] = useState(true)
+    const [error, setError] = useState(undefined)
+    const [data, setData] = useState(null)
+
+    useEffect(() => {
+        mounted.current = true
+        setFetching(true)
+
+        const doFetch = async () => {
+            try {
+                const analyticsResponse = await fetchAnalyticsData({
+                    analyticsEngine,
+                    visualization,
+                    pageSize,
+                    page,
+                    relativePeriodDate,
+                    sortField,
+                    sortDirection,
+                })
+                const headers = reduceHeaders(analyticsResponse, visualization)
+                const rows = reduceRows(analyticsResponse, headers)
+                const pageCount = analyticsResponse.metaData.pager.pageCount
+                const total = analyticsResponse.metaData.pager.total
+
+                mounted.current && setError(undefined)
+                mounted.current && setData({ headers, rows, pageCount, total })
+
+                onResponseReceived(analyticsResponse)
+            } catch (error) {
+                mounted.current && setError(error)
+            } finally {
+                mounted.current && setLoading(false)
+                mounted.current && setFetching(false)
+            }
+        }
+
+        doFetch()
+
+        return () => {
+            // Hack to prevent state updates on unmounted components
+            // needed because the analytics engine cannot cancel requests
+            mounted.current = false
+        }
+    }, [
+        visualization,
+        page,
+        pageSize,
+        sortField,
+        sortDirection,
+        relativePeriodDate,
+    ])
+
+    return {
+        loading,
+        fetching,
+        error,
+        data,
+    }
+}
+
+export { useAnalyticsData }


### PR DESCRIPTION
Implements [TECH-825](https://jira.dhis2.org/browse/TECH-825)

---

### Key features

1. Use SWR in the `Visualization` component to avoid content shifts when interacting with the visualisation in the modal
2. Extract the `Visualization` component's data fetching logic into a hook
3. Show loading errors in the `Visualisation` component
4. Fix content shift in the modal on first load
5. Switch the global `isVisualizationLoading` state to `false` when closing the modal

---

### Description

I've reworked the Visualization component a bit. The code has been refactored so that the data logic is extracted into a hook. Functionality-wise I've also added support for rendering errors, but the biggest change is that this component now uses the SWR model. **S**tale **W**hile **R**evalidate means that we keep the old data in place while we are fetching the new data, and to indicate the data the user is currently viewing is stale, we show a loading indicator _on top of_ the stale data.

After applying SWR the content shifts in the modal are fairly limited. The user can sort data, navigate through pages, and the size of the table will remain relatively constant. We can probably do even more to keep the modal completely still, but this is already a vast improvement.

The above fixes the content shifts _once the modal has rendered_ and the user starts interacting with it. But that was only part of the problem. The modal worst content shift was happening when the modal was opening along with the app (i.e. when there is an `interpretationId` in the URL query params). The root cause of this content shift was caused by the fact that I was using the global `isVisualizationLoading` redux state property to determine when to show the modal. However, since this global variable is used by the main visualisation as well, this wasn't working properly: the main visualisation would be done loading when the visualisation in the modal wasn't done yet and this would cause the modal to render without the visualisation. To remedy this, the modal now has its own internal loading state.

~Even though the interpretation modal itself is now fully independent of the global loading state, opening it is still causing some changes in the global state via the history listener in `App.js`. It could be that we want to completely disable this behaviour later on, but I decided to keep it for now, because it also comes with some advantages: I am not showing the modal until all of its parts are done rendering, so this can take some time. The current behaviour ensures that the main UI goes into a loading state while the users waits for the modal to show, so that's nice. The downside of the current behaviour was that the main UI would keep that loading state when closing the modal. But it turns out this was [extremely easy to fix](https://github.com/dhis2/event-reports-app/blob/026275f8793aea92bca56801797de75a3f990f05/src/components/InterpretationModal/InterpretationModal.js#L21-L24), so I decided to just implement the quick fix for now. Refactoring the state might still be useful, but we can defer that until when all the moving parts are in place.~ This is no longer accurate, I've addressed this in baf705f, 3454408, 3f64840 and 4d83236. The modal now has it's own loader UI and is completely independent from the global state 🚀 .

----

