### PR TITLE
fix: fix visualization types passed to the AO

### DIFF
--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -4,8 +4,8 @@ import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
 import { default as options } from './options.js'
 
-export const VIS_TYPE_PIVOT_TABLE = 'VIS_TYPE_PIVOT_TABLE'
-export const VIS_TYPE_LINE_LIST = 'VIS_TYPE_LINE_LIST'
+export const VIS_TYPE_PIVOT_TABLE = 'PIVOT_TABLE'
+export const VIS_TYPE_LINE_LIST = 'LINE_LIST'
 
 export const visTypeMap = {
     [VIS_TYPE_LINE_LIST]: {


### PR DESCRIPTION
### Key features

1. fix incorrect visualization `type`

---

### Description

Saving an ER AO was failing due to a non-recognised value for `type`.
The correct 2 types are `LINE_LIST` and `PIVOT_TABLE`.