### PR TITLE
feat: TRUE_ONLY condition type (TECH-815)

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -160,7 +160,7 @@ const App = ({
         const onMount = async () => {
             await addSettings(userSettings)
             setUser(d2.currentUser)
-            await setLegendSets()
+            await setLegendSets() // TODO: Only fetch this on-demand, rather than on app load!
             await setDimensions()
 
             setInitMetadata()

--- a/src/components/Dialogs/Conditions/BooleanCondition.js
+++ b/src/components/Dialogs/Conditions/BooleanCondition.js
@@ -10,7 +10,6 @@ const TRUE_VALUE = '1'
 const FALSE_VALUE = '0'
 
 const BooleanCondition = ({ condition, onChange, showFalseOption }) => {
-    // TODO: param for hiding FALSE for the TRUE_ONLY type... or split this to a separate component?
     const parts = condition.split(':')
     const values = parts[1] || ''
 

--- a/src/components/Dialogs/Conditions/BooleanCondition.js
+++ b/src/components/Dialogs/Conditions/BooleanCondition.js
@@ -9,7 +9,7 @@ const NULL_VALUE = 'NV'
 const TRUE_VALUE = '1'
 const FALSE_VALUE = '0'
 
-const BooleanCondition = ({ condition, onChange }) => {
+const BooleanCondition = ({ condition, onChange, showFalseOption }) => {
     // TODO: param for hiding FALSE for the TRUE_ONLY type... or split this to a separate component?
     const parts = condition.split(':')
     const values = parts[1] || ''
@@ -38,15 +38,17 @@ const BooleanCondition = ({ condition, onChange }) => {
                 dense
                 className={classes.checkboxOption}
             />
-            <Checkbox
-                checked={values.includes(FALSE_VALUE)}
-                label={i18n.t('No')}
-                onChange={({ checked }) =>
-                    onCheckboxChange(FALSE_VALUE, checked)
-                }
-                dense
-                className={classes.checkboxOption}
-            />
+            {showFalseOption && (
+                <Checkbox
+                    checked={values.includes(FALSE_VALUE)}
+                    label={i18n.t('No')}
+                    onChange={({ checked }) =>
+                        onCheckboxChange(FALSE_VALUE, checked)
+                    }
+                    dense
+                    className={classes.checkboxOption}
+                />
+            )}
             <Checkbox
                 checked={values.includes(NULL_VALUE)}
                 label={i18n.t('Not answered')}
@@ -63,6 +65,7 @@ const BooleanCondition = ({ condition, onChange }) => {
 BooleanCondition.propTypes = {
     condition: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    showFalseOption: PropTypes.boolean,
 }
 
 export default BooleanCondition

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -35,6 +35,7 @@ const DIMENSION_TYPE_EMAIL = 'EMAIL'
 const DIMENSION_TYPE_USERNAME = 'USERNAME'
 const DIMENSION_TYPE_URL = 'URL'
 const DIMENSION_TYPE_BOOLEAN = 'BOOLEAN'
+const DIMENSION_TYPE_TRUE_ONLY = 'TRUE_ONLY'
 
 const NUMERIC_TYPES = [
     DIMENSION_TYPE_NUMBER,
@@ -46,7 +47,7 @@ const NUMERIC_TYPES = [
     DIMENSION_TYPE_INTEGER_ZERO_OR_POSITIVE,
 ]
 
-const SINGLETON_TYPES = [DIMENSION_TYPE_BOOLEAN]
+const SINGLETON_TYPES = [DIMENSION_TYPE_BOOLEAN, DIMENSION_TYPE_TRUE_ONLY]
 
 const EMPTY_CONDITION = ''
 
@@ -58,7 +59,7 @@ const ConditionsManager = ({
     onClose,
     setConditionsByDimension,
 }) => {
-    const dimensionType = DIMENSION_TYPE_TEXT // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
+    const dimensionType = DIMENSION_TYPE_TRUE_ONLY // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
 
     const [conditionsList, setConditionsList] = useState(
         (conditions.condition?.length &&
@@ -182,13 +183,16 @@ const ConditionsManager = ({
                     </div>
                 ))
             }
-            case DIMENSION_TYPE_BOOLEAN: {
+            case DIMENSION_TYPE_BOOLEAN:
+            case DIMENSION_TYPE_TRUE_ONLY: {
+                const showFalseOption = dimensionType === DIMENSION_TYPE_BOOLEAN
                 return (conditionsList.length && conditionsList).map(
                     (condition, index) => (
                         <div key={index}>
                             <BooleanCondition
                                 condition={condition}
                                 onChange={(value) => setCondition(index, value)}
+                                showFalseOption={showFalseOption}
                             />
                         </div>
                     )

--- a/src/reducers/legendSets.js
+++ b/src/reducers/legendSets.js
@@ -12,4 +12,6 @@ export default (state = DEFAULT_LEGEND_SETS, action) => {
     }
 }
 
-export const sGetLegendSets = (state) => state.legendSets
+//export const sGetLegendSets = (state) => state.legendSets
+// TODO: Note that fetching the legend sets should be done on demand, currently its being done on app load which isn't ideal.
+// When implementing a use-case for sGetLegendSets, consider refactoring this to actually just be stored in the component state rather than the redux store


### PR DESCRIPTION
Implements [TECH-815](https://jira.dhis2.org/browse/TECH-815)
Continues / extends https://github.com/dhis2/event-reports-app/pull/882

---

### Key features

1. Hides `false` from the `BooleanCondition` to facilitate `TRUE_ONLY`

---

### Description
`TRUE_ONLY` is a boolean without a `false` option. Hence `BooleanCondition.js` was adapted to facilitate both the regular `BOOLEAN` and the new type.

---

### Screenshots

![image](https://user-images.githubusercontent.com/12590483/146785075-d1d863aa-248f-4cdf-a183-99662dc11766.png)
