### PR TITLE
feat: date, datetime, time conditions (TECH-817)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-17T09:28:10.425Z\n"
-"PO-Revision-Date: 2021-12-17T09:28:10.425Z\n"
+"POT-Creation-Date: 2021-12-21T10:14:42.618Z\n"
+"PO-Revision-Date: 2021-12-21T10:14:42.618Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -65,6 +65,18 @@ msgstr "Add another condition"
 
 msgid "Add a condition"
 msgstr "Add a condition"
+
+msgid "after"
+msgstr "after"
+
+msgid "after and including"
+msgstr "after and including"
+
+msgid "before"
+msgstr "before"
+
+msgid "before or including"
+msgstr "before or including"
 
 msgid "equal to (=)"
 msgstr "equal to (=)"

--- a/src/components/Dialogs/Conditions/AlphanumericCondition.js
+++ b/src/components/Dialogs/Conditions/AlphanumericCondition.js
@@ -71,7 +71,7 @@ const checkIsCaseSensitive = (operator) => {
     }
 }
 
-const AlphanumericCondition = ({
+const BaseCondition = ({
     condition,
     onChange,
     onRemove,
@@ -153,11 +153,15 @@ const AlphanumericCondition = ({
     )
 }
 
-AlphanumericCondition.propTypes = {
+BaseCondition.propTypes = {
     condition: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
     allowCaseSensitive: PropTypes.bool,
 }
 
-export default AlphanumericCondition
+export const AlphanumericCondition = (props) => <BaseCondition {...props} />
+
+export const CaseSensitiveAlphanumericCondition = (props) => (
+    <BaseCondition allowCaseSensitive={true} {...props} />
+)

--- a/src/components/Dialogs/Conditions/AlphanumericCondition.js
+++ b/src/components/Dialogs/Conditions/AlphanumericCondition.js
@@ -8,17 +8,18 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import {
+    NULL_VALUE,
+    OPERATOR_CONTAINS,
+    OPERATOR_EMPTY,
+    OPERATOR_EQUAL,
+    OPERATOR_NOT_CONTAINS,
+    OPERATOR_NOT_EMPTY,
+    OPERATOR_NOT_EQUAL,
+    CASE_SENSITIVE_PREFIX,
+    NOT_PREFIX,
+} from '../../../modules/conditions.js'
 import classes from './styles/Condition.module.css'
-
-const CASE_SENSITIVE_PREFIX = 'I'
-const NOT_PREFIX = '!'
-const NULL_VALUE = 'NV'
-export const OPERATOR_EQUAL = 'EQ'
-export const OPERATOR_NOT_EQUAL = '!EQ'
-export const OPERATOR_CONTAINS = 'LIKE'
-export const OPERATOR_NOT_CONTAINS = '!LIKE'
-export const OPERATOR_EMPTY = `EQ:${NULL_VALUE}`
-export const OPERATOR_NOT_EMPTY = `NE:${NULL_VALUE}`
 
 const operators = {
     [OPERATOR_EQUAL]: i18n.t('exactly'),

--- a/src/components/Dialogs/Conditions/BooleanCondition.js
+++ b/src/components/Dialogs/Conditions/BooleanCondition.js
@@ -9,7 +9,7 @@ const NULL_VALUE = 'NV'
 const TRUE_VALUE = '1'
 const FALSE_VALUE = '0'
 
-const BooleanCondition = ({ condition, onChange, showFalseOption }) => {
+const BaseCondition = ({ condition, onChange, showFalseOption }) => {
     const parts = condition.split(':')
     const values = parts[1] || ''
 
@@ -61,10 +61,14 @@ const BooleanCondition = ({ condition, onChange, showFalseOption }) => {
     )
 }
 
-BooleanCondition.propTypes = {
+BaseCondition.propTypes = {
     condition: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     showFalseOption: PropTypes.boolean,
 }
 
-export default BooleanCondition
+export const BooleanCondition = (props) => (
+    <BaseCondition showFalseOption={true} {...props} />
+)
+
+export const TrueOnlyCondition = (props) => <BaseCondition {...props} />

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -71,7 +71,8 @@ const ConditionsManager = ({
     onClose,
     setConditionsByDimension,
 }) => {
-    const dimensionType = DIMENSION_TYPE_TIME // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
+    // const dimensionType = dimension.type
+    const dimensionType = DIMENSION_TYPE_DATE // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
 
     const [conditionsList, setConditionsList] = useState(
         (conditions.condition?.length &&

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -16,7 +16,10 @@ import {
     sGetUiConditionsByDimension,
 } from '../../../reducers/ui.js'
 import DimensionModal from '../DimensionModal.js'
-import AlphanumericCondition from './AlphanumericCondition.js'
+import {
+    AlphanumericCondition,
+    CaseSensitiveAlphanumericCondition,
+} from './AlphanumericCondition.js'
 import { BooleanCondition, TrueOnlyCondition } from './BooleanCondition.js'
 import {
     DateCondition,
@@ -171,22 +174,30 @@ const ConditionsManager = ({
                     </div>
                 ))
             }
-            case DIMENSION_TYPE_TEXT:
-            case DIMENSION_TYPE_LONG_TEXT:
-            case DIMENSION_TYPE_LETTER:
-            case DIMENSION_TYPE_PHONE_NUMBER:
-            case DIMENSION_TYPE_EMAIL:
-            case DIMENSION_TYPE_USERNAME:
-            case DIMENSION_TYPE_URL: {
-                const allowCaseSensitive =
-                    dimensionType !== DIMENSION_TYPE_PHONE_NUMBER
+            case DIMENSION_TYPE_PHONE_NUMBER: {
                 return conditionsList.map((condition, index) => (
                     <div key={index}>
                         <AlphanumericCondition
                             condition={condition}
                             onChange={(value) => setCondition(index, value)}
                             onRemove={() => removeCondition(index)}
-                            allowCaseSensitive={allowCaseSensitive}
+                        />
+                        {getDividerContent(index)}
+                    </div>
+                ))
+            }
+            case DIMENSION_TYPE_TEXT:
+            case DIMENSION_TYPE_LONG_TEXT:
+            case DIMENSION_TYPE_LETTER:
+            case DIMENSION_TYPE_EMAIL:
+            case DIMENSION_TYPE_USERNAME:
+            case DIMENSION_TYPE_URL: {
+                return conditionsList.map((condition, index) => (
+                    <div key={index}>
+                        <CaseSensitiveAlphanumericCondition
+                            condition={condition}
+                            onChange={(value) => setCondition(index, value)}
+                            onRemove={() => removeCondition(index)}
                         />
                         {getDividerContent(index)}
                     </div>

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -17,7 +17,7 @@ import {
 } from '../../../reducers/ui.js'
 import DimensionModal from '../DimensionModal.js'
 import AlphanumericCondition from './AlphanumericCondition.js'
-import BooleanCondition from './BooleanCondition.js'
+import { BooleanCondition, TrueOnlyCondition } from './BooleanCondition.js'
 import {
     DateCondition,
     DateTimeCondition,
@@ -192,16 +192,25 @@ const ConditionsManager = ({
                     </div>
                 ))
             }
-            case DIMENSION_TYPE_BOOLEAN:
-            case DIMENSION_TYPE_TRUE_ONLY: {
-                const showFalseOption = dimensionType === DIMENSION_TYPE_BOOLEAN
+            case DIMENSION_TYPE_BOOLEAN: {
                 return (conditionsList.length && conditionsList).map(
                     (condition, index) => (
                         <div key={index}>
                             <BooleanCondition
                                 condition={condition}
                                 onChange={(value) => setCondition(index, value)}
-                                showFalseOption={showFalseOption}
+                            />
+                        </div>
+                    )
+                )
+            }
+            case DIMENSION_TYPE_TRUE_ONLY: {
+                return (conditionsList.length && conditionsList).map(
+                    (condition, index) => (
+                        <div key={index}>
+                            <TrueOnlyCondition
+                                condition={condition}
+                                onChange={(value) => setCondition(index, value)}
                             />
                         </div>
                     )

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -206,22 +206,22 @@ const ConditionsManager = ({
             }
             case DIMENSION_TYPE_BOOLEAN: {
                 return conditionsList.map((condition, index) => (
-                        <div key={index}>
-                            <BooleanCondition
-                                condition={condition}
-                                onChange={(value) => setCondition(index, value)}
-                            />
-                        </div>
+                    <div key={index}>
+                        <BooleanCondition
+                            condition={condition}
+                            onChange={(value) => setCondition(index, value)}
+                        />
+                    </div>
                 ))
             }
             case DIMENSION_TYPE_TRUE_ONLY: {
                 return conditionsList.map((condition, index) => (
-                        <div key={index}>
-                            <TrueOnlyCondition
-                                condition={condition}
-                                onChange={(value) => setCondition(index, value)}
-                            />
-                        </div>
+                    <div key={index}>
+                        <TrueOnlyCondition
+                            condition={condition}
+                            onChange={(value) => setCondition(index, value)}
+                        />
+                    </div>
                 ))
             }
             case DIMENSION_TYPE_DATE: {

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -18,7 +18,11 @@ import {
 import DimensionModal from '../DimensionModal.js'
 import AlphanumericCondition from './AlphanumericCondition.js'
 import BooleanCondition from './BooleanCondition.js'
-import DateCondition from './DateCondition.js'
+import {
+    DateCondition,
+    DateTimeCondition,
+    TimeCondition,
+} from './DateCondition.js'
 import NumericCondition from './NumericCondition.js'
 import classes from './styles/ConditionsManager.module.css'
 
@@ -39,6 +43,8 @@ const DIMENSION_TYPE_URL = 'URL'
 const DIMENSION_TYPE_BOOLEAN = 'BOOLEAN'
 const DIMENSION_TYPE_TRUE_ONLY = 'TRUE_ONLY'
 const DIMENSION_TYPE_DATE = 'DATE'
+const DIMENSION_TYPE_TIME = 'TIME'
+const DIMENSION_TYPE_DATETIME = 'DATETIME'
 
 const NUMERIC_TYPES = [
     DIMENSION_TYPE_NUMBER,
@@ -62,7 +68,7 @@ const ConditionsManager = ({
     onClose,
     setConditionsByDimension,
 }) => {
-    const dimensionType = DIMENSION_TYPE_DATE // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
+    const dimensionType = DIMENSION_TYPE_TIME // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
 
     const [conditionsList, setConditionsList] = useState(
         (conditions.condition?.length &&
@@ -205,6 +211,30 @@ const ConditionsManager = ({
                 return conditionsList.map((condition, index) => (
                     <div key={index}>
                         <DateCondition
+                            condition={condition}
+                            onChange={(value) => setCondition(index, value)}
+                            onRemove={() => removeCondition(index)}
+                        />
+                        {getDividerContent(index)}
+                    </div>
+                ))
+            }
+            case DIMENSION_TYPE_TIME: {
+                return conditionsList.map((condition, index) => (
+                    <div key={index}>
+                        <TimeCondition
+                            condition={condition}
+                            onChange={(value) => setCondition(index, value)}
+                            onRemove={() => removeCondition(index)}
+                        />
+                        {getDividerContent(index)}
+                    </div>
+                ))
+            }
+            case DIMENSION_TYPE_DATETIME: {
+                return conditionsList.map((condition, index) => (
+                    <div key={index}>
+                        <DateTimeCondition
                             condition={condition}
                             onChange={(value) => setCondition(index, value)}
                             onRemove={() => removeCondition(index)}

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -205,28 +205,24 @@ const ConditionsManager = ({
                 ))
             }
             case DIMENSION_TYPE_BOOLEAN: {
-                return (conditionsList.length && conditionsList).map(
-                    (condition, index) => (
+                return conditionsList.map((condition, index) => (
                         <div key={index}>
                             <BooleanCondition
                                 condition={condition}
                                 onChange={(value) => setCondition(index, value)}
                             />
                         </div>
-                    )
-                )
+                ))
             }
             case DIMENSION_TYPE_TRUE_ONLY: {
-                return (conditionsList.length && conditionsList).map(
-                    (condition, index) => (
+                return conditionsList.map((condition, index) => (
                         <div key={index}>
                             <TrueOnlyCondition
                                 condition={condition}
                                 onChange={(value) => setCondition(index, value)}
                             />
                         </div>
-                    )
-                )
+                ))
             }
             case DIMENSION_TYPE_DATE: {
                 return conditionsList.map((condition, index) => (

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { tSetCurrentFromUi } from '../../../actions/current.js'
 import { tSetUiConditionsByDimension } from '../../../actions/ui.js'
 import {
+    OPERATOR_RANGE_SET,
     parseConditionsArrayToString,
     parseConditionsStringToArray,
 } from '../../../modules/conditions.js'
@@ -17,7 +18,8 @@ import {
 import DimensionModal from '../DimensionModal.js'
 import AlphanumericCondition from './AlphanumericCondition.js'
 import BooleanCondition from './BooleanCondition.js'
-import NumericCondition, { OPERATOR_RANGE_SET } from './NumericCondition.js'
+import DateCondition from './DateCondition.js'
+import NumericCondition from './NumericCondition.js'
 import classes from './styles/ConditionsManager.module.css'
 
 const DIMENSION_TYPE_NUMBER = 'NUMBER'
@@ -36,6 +38,7 @@ const DIMENSION_TYPE_USERNAME = 'USERNAME'
 const DIMENSION_TYPE_URL = 'URL'
 const DIMENSION_TYPE_BOOLEAN = 'BOOLEAN'
 const DIMENSION_TYPE_TRUE_ONLY = 'TRUE_ONLY'
+const DIMENSION_TYPE_DATE = 'DATE'
 
 const NUMERIC_TYPES = [
     DIMENSION_TYPE_NUMBER,
@@ -59,7 +62,7 @@ const ConditionsManager = ({
     onClose,
     setConditionsByDimension,
 }) => {
-    const dimensionType = DIMENSION_TYPE_TRUE_ONLY // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
+    const dimensionType = DIMENSION_TYPE_DATE // TODO: Should be returned by the backend, e.g. NUMBER, INTEGER, PERCENTAGE
 
     const [conditionsList, setConditionsList] = useState(
         (conditions.condition?.length &&
@@ -197,6 +200,18 @@ const ConditionsManager = ({
                         </div>
                     )
                 )
+            }
+            case DIMENSION_TYPE_DATE: {
+                return conditionsList.map((condition, index) => (
+                    <div key={index}>
+                        <DateCondition
+                            condition={condition}
+                            onChange={(value) => setCondition(index, value)}
+                            onRemove={() => removeCondition(index)}
+                        />
+                        {getDividerContent(index)}
+                    </div>
+                ))
             }
         }
     }

--- a/src/components/Dialogs/Conditions/DateCondition.js
+++ b/src/components/Dialogs/Conditions/DateCondition.js
@@ -15,6 +15,10 @@ import {
 } from '../../../modules/conditions.js'
 import classes from './styles/Condition.module.css'
 
+const TYPE_DATE = 'date'
+const TYPE_DATETIME = 'datetime-local'
+const TYPE_TIME = 'time'
+
 const operators = {
     [OPERATOR_EQUAL]: i18n.t('exactly'),
     [OPERATOR_NOT_EQUAL]: i18n.t('is not'),
@@ -26,8 +30,10 @@ const operators = {
     [OPERATOR_NOT_EMPTY]: i18n.t('is not empty / not null'),
 }
 
-// TODO: Implement DATETIME and TIME (only) input as well... or break out to separate component?
-const DateCondition = ({ condition, onChange, onRemove }) => {
+const API_TIME_DIVIDER = '.' // TODO: Currently just picked a random character, use the correct character preferred by backend
+const UI_TIME_DIVIDER = ':'
+
+const BaseCondition = ({ condition, onChange, onRemove, type }) => {
     let operator, value
 
     if (condition.includes(NULL_VALUE)) {
@@ -47,7 +53,11 @@ const DateCondition = ({ condition, onChange, onRemove }) => {
     }
 
     const setValue = (input) => {
-        onChange(`${operator}:${input || ''}`)
+        onChange(
+            `${operator}:${
+                input.replaceAll(UI_TIME_DIVIDER, API_TIME_DIVIDER) || ''
+            }`
+        )
     }
 
     return (
@@ -69,8 +79,8 @@ const DateCondition = ({ condition, onChange, onRemove }) => {
             </SingleSelectField>
             {operator && !operator.includes(NULL_VALUE) && (
                 <Input
-                    value={value}
-                    type="date"
+                    value={value.replaceAll(API_TIME_DIVIDER, UI_TIME_DIVIDER)}
+                    type={type}
                     onChange={({ value }) => setValue(value)}
                     width="150px"
                     dense
@@ -89,10 +99,21 @@ const DateCondition = ({ condition, onChange, onRemove }) => {
     )
 }
 
-DateCondition.propTypes = {
+BaseCondition.propTypes = {
     condition: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onRemove: PropTypes.func.isRequired,
 }
 
-export default DateCondition
+export const DateCondition = (props) => (
+    <BaseCondition type={TYPE_DATE} {...props} />
+)
+
+export const DateTimeCondition = (props) => (
+    <BaseCondition type={TYPE_DATETIME} {...props} />
+)
+
+export const TimeCondition = (props) => (
+    <BaseCondition type={TYPE_TIME} {...props} />
+)

--- a/src/components/Dialogs/Conditions/DateCondition.js
+++ b/src/components/Dialogs/Conditions/DateCondition.js
@@ -26,6 +26,7 @@ const operators = {
     [OPERATOR_NOT_EMPTY]: i18n.t('is not empty / not null'),
 }
 
+// TODO: Implement DATETIME and TIME (only) input as well... or break out to separate component?
 const DateCondition = ({ condition, onChange, onRemove }) => {
     let operator, value
 
@@ -69,7 +70,7 @@ const DateCondition = ({ condition, onChange, onRemove }) => {
             {operator && !operator.includes(NULL_VALUE) && (
                 <Input
                     value={value}
-                    type="text"
+                    type="date"
                     onChange={({ value }) => setValue(value)}
                     width="150px"
                     dense

--- a/src/components/Dialogs/Conditions/DateCondition.js
+++ b/src/components/Dialogs/Conditions/DateCondition.js
@@ -1,0 +1,97 @@
+import i18n from '@dhis2/d2-i18n'
+import { SingleSelectField, SingleSelectOption, Button, Input } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import {
+    NULL_VALUE,
+    OPERATOR_EQUAL,
+    OPERATOR_NOT_EQUAL,
+    OPERATOR_GREATER,
+    OPERATOR_GREATER_OR_EQUAL,
+    OPERATOR_LESS,
+    OPERATOR_LESS_OR_EQUAL,
+    OPERATOR_EMPTY,
+    OPERATOR_NOT_EMPTY,
+} from '../../../modules/conditions.js'
+import classes from './styles/Condition.module.css'
+
+const operators = {
+    [OPERATOR_EQUAL]: i18n.t('exactly'),
+    [OPERATOR_NOT_EQUAL]: i18n.t('is not'),
+    [OPERATOR_GREATER]: i18n.t('after'),
+    [OPERATOR_GREATER_OR_EQUAL]: i18n.t('after and including'),
+    [OPERATOR_LESS]: i18n.t('before'),
+    [OPERATOR_LESS_OR_EQUAL]: i18n.t('before or including'),
+    [OPERATOR_EMPTY]: i18n.t('is empty / null'),
+    [OPERATOR_NOT_EMPTY]: i18n.t('is not empty / not null'),
+}
+
+const DateCondition = ({ condition, onChange, onRemove }) => {
+    let operator, value
+
+    if (condition.includes(NULL_VALUE)) {
+        operator = condition
+    } else {
+        const parts = condition.split(':')
+        operator = parts[0]
+        value = parts[1]
+    }
+
+    const setOperator = (input) => {
+        if (input.includes(NULL_VALUE)) {
+            onChange(`${input}`)
+        } else {
+            onChange(`${input}:${value || ''}`)
+        }
+    }
+
+    const setValue = (input) => {
+        onChange(`${operator}:${input || ''}`)
+    }
+
+    return (
+        <div className={classes.container}>
+            <SingleSelectField
+                selected={operator}
+                inputWidth="180px"
+                placeholder={i18n.t('Choose a condition type')}
+                dense
+                onChange={({ selected }) => setOperator(selected)}
+            >
+                {Object.keys(operators).map((key) => (
+                    <SingleSelectOption
+                        key={key}
+                        value={key}
+                        label={operators[key]}
+                    />
+                ))}
+            </SingleSelectField>
+            {operator && !operator.includes(NULL_VALUE) && (
+                <Input
+                    value={value}
+                    type="text"
+                    onChange={({ value }) => setValue(value)}
+                    width="150px"
+                    dense
+                />
+            )}
+            <Button
+                type="button"
+                small
+                secondary
+                onClick={onRemove}
+                className={classes.removeButton}
+            >
+                {i18n.t('Remove')}
+            </Button>
+        </div>
+    )
+}
+
+DateCondition.propTypes = {
+    condition: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired,
+}
+
+export default DateCondition

--- a/src/components/Dialogs/Conditions/NumericCondition.js
+++ b/src/components/Dialogs/Conditions/NumericCondition.js
@@ -10,18 +10,20 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import {
+    OPERATOR_EQUAL,
+    OPERATOR_GREATER,
+    OPERATOR_GREATER_OR_EQUAL,
+    OPERATOR_LESS,
+    OPERATOR_LESS_OR_EQUAL,
+    OPERATOR_NOT_EQUAL,
+    OPERATOR_EMPTY,
+    OPERATOR_NOT_EMPTY,
+    OPERATOR_RANGE_SET,
+} from '../../../modules/conditions.js'
 import classes from './styles/Condition.module.css'
 
 const NULL_VALUE = 'NV'
-export const OPERATOR_EQUAL = 'EQ'
-export const OPERATOR_GREATER = 'GT'
-export const OPERATOR_GREATER_OR_EQUAL = 'GE'
-export const OPERATOR_LESS = 'LT'
-export const OPERATOR_LESS_OR_EQUAL = 'LE'
-export const OPERATOR_NOT_EQUAL = '!EQ'
-export const OPERATOR_EMPTY = `EQ:${NULL_VALUE}`
-export const OPERATOR_NOT_EMPTY = `NE:${NULL_VALUE}`
-export const OPERATOR_RANGE_SET = 'IN'
 
 const operators = {
     [OPERATOR_EQUAL]: i18n.t('equal to (=)'),

--- a/src/modules/conditions.js
+++ b/src/modules/conditions.js
@@ -5,3 +5,18 @@ export const parseConditionsStringToArray = (conditionsString) =>
 // parse e.g. ['LT:25', 'GT:15'] to 'LT:25:GT:15'
 export const parseConditionsArrayToString = (conditionsArray) =>
     conditionsArray.join(':')
+
+export const NULL_VALUE = 'NV'
+export const OPERATOR_EQUAL = 'EQ'
+export const OPERATOR_GREATER = 'GT'
+export const OPERATOR_GREATER_OR_EQUAL = 'GE'
+export const OPERATOR_LESS = 'LT'
+export const OPERATOR_LESS_OR_EQUAL = 'LE'
+export const OPERATOR_NOT_EQUAL = '!EQ'
+export const OPERATOR_EMPTY = `EQ:${NULL_VALUE}`
+export const OPERATOR_NOT_EMPTY = `NE:${NULL_VALUE}`
+export const OPERATOR_RANGE_SET = 'IN'
+export const OPERATOR_CONTAINS = 'LIKE'
+export const OPERATOR_NOT_CONTAINS = '!LIKE'
+export const CASE_SENSITIVE_PREFIX = 'I'
+export const NOT_PREFIX = '!'


### PR DESCRIPTION
Implements [TECH-817](https://jira.dhis2.org/browse/TECH-817)

Spec: [ER:C6: Condition selector](https://docs.google.com/document/d/1qrcLpVymdBpgzJyJ3IPULtotCQdg2PWnQL-AlgntMz4/edit#)

---

### Key features

1. Implement date, datetime, time conditions
2. Refactor all other condition types to follow the same prop signature

---

### Description

_feat_: Generally follows the pattern used for the numeric, alphanumeric and boolean conditions to implement date / datetime / time conditions. Main exception is that instead of having a single export with props to toggle various parts, separate exports for each sub-type are used.

_refactor_: All the previous condition types have all been refactored to use this new format with separately exported components rather than proprietary props unique to each condition type. This results in all conditions now use a much simpler unified prop signature instead: `condition`, `onChange` and the optional `onRemove`.

_refactor_: All condition operators and consts were moved to `/modules/conditions.js` instead of redundantly being defined in each condition file.

_note_: As `:` is reserved for splitting `condition:value` in the backend, its assumed that this format won't valid to use for the hour/minute divider (e.g. `15:30`), so instead the backend format is parsed to `:` before being passed on to the `ui` component (that expects `:`). However, as the preferred backend format / divider character is unknown, `.` (a single dot) is used in its place temporarily. This of course means that the `datetime` and `time` condition types won't work with the API for now.

---

### TODO

-   [ ] Change the `API_TIME_DIVIDER` to the proper character used by the backend

---

### Screenshots

_date_

![image](https://user-images.githubusercontent.com/12590483/146940399-35edb3d3-efa4-442c-b586-af1c1a0387e4.png)


_time_

![image](https://user-images.githubusercontent.com/12590483/146940486-4326ec23-4f07-46c9-b3c5-69ef9c936297.png)


_datetime_

![image](https://user-images.githubusercontent.com/12590483/146940604-fb178e94-7d00-400f-a1b5-26deddf4e3a4.png)


