### PR TITLE
fix: close the DownloadMenu when clicking outside of it

### DIFF
--- a/src/components/DownloadMenu/ToolbarDownloadDropdown.js
+++ b/src/components/DownloadMenu/ToolbarDownloadDropdown.js
@@ -18,7 +18,7 @@ const ToolbarDownloadDropdown = () => {
                 {i18n.t('Download')}
             </MenuButton>
             {isOpen && (
-                <Layer onClick={() => toggleOpen}>
+                <Layer onClick={toggleOpen}>
                     <Popper reference={buttonRef} placement="bottom-start">
                         <DownloadMenu download={download} />
                     </Popper>


### PR DESCRIPTION
### Key features

1. Fix bug in DownloadMenu

---

### Description

The DownloadMenu opened from the Toolbar couldn't be closed by clicking outside of it.