### PR TITLE
fix: save and fetch options to/from metadata with code (TECH-816)

### DIFF
--- a/src/api/options.js
+++ b/src/api/options.js
@@ -8,7 +8,7 @@ const optionsQuery = {
         }
 
         return {
-            fields: 'code,name',
+            fields: 'code,name,id',
             filter: filters,
             paging: true,
             page,

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -143,6 +143,7 @@ const App = ({
                     name: item.name || item.displayName,
                     displayName: item.displayName,
                     dimensionItemType: item.dimensionItemType, // TODO needed?
+                    code: item.code,
                 }
 
                 return obj

--- a/src/components/Dialogs/Conditions/OptionSetCondition.js
+++ b/src/components/Dialogs/Conditions/OptionSetCondition.js
@@ -4,6 +4,7 @@ import { InputField, Transfer, TransferOption } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { connect } from 'react-redux'
+import { acAddMetadata } from '../../../actions/metadata.js'
 import { apiFetchOptions } from '../../../api/options.js'
 import { OPERATOR_IN } from '../../../modules/conditions.js'
 import { useDebounce, useDidUpdateEffect } from '../../../modules/utils.js'
@@ -66,16 +67,24 @@ const OptionSetCondition = ({
     onChange,
     displayNameProp,
     metadata,
+    addMetadata,
 }) => {
     const parts = condition.split(':')
     const values = parts[1]?.length ? parts[1].split(';') : []
     const selectedOptions = values.map((code) => ({
         code,
-        name: metadata[code]?.name, // FIXME: Doesn't work as metadata stores the options with an id that's separate from the code
+        name: Object.values(metadata).find((item) => item.code === code).name,
     }))
     const dataTest = 'option-set'
 
     const setValues = (selected) => {
+        addMetadata(
+            state.options
+                .filter((item) => selected.includes(item.code))
+                .map((item) => ({
+                    [item.id]: item,
+                }))
+        )
         onChange(`${OPERATOR_IN}:${selected.join(';') || ''}`)
     }
 
@@ -103,6 +112,7 @@ const OptionSetCondition = ({
             newOptions.push({
                 name: item.name,
                 code: item.code,
+                id: item.id,
             })
         })
         setState((state) => ({
@@ -190,6 +200,7 @@ const OptionSetCondition = ({
 }
 
 OptionSetCondition.propTypes = {
+    addMetadata: PropTypes.func.isRequired,
     condition: PropTypes.string.isRequired,
     displayNameProp: PropTypes.string.isRequired,
     metadata: PropTypes.object.isRequired,
@@ -202,4 +213,6 @@ const mapStateToProps = (state) => ({
     metadata: sGetMetadata(state),
 })
 
-export default connect(mapStateToProps)(OptionSetCondition)
+export default connect(mapStateToProps, { addMetadata: acAddMetadata })(
+    OptionSetCondition
+)


### PR DESCRIPTION
Implements [TECH-816](https://jira.dhis2.org/browse/TECH-816)

---

### Key features

1. Saves and fetches metadata for options that previously only had `code`

---

### Description

Options use `code` as their identifier instead of `id`. This led to some issue with metadata (`name`) being missing from options that weren't "in scope" in the `Transfer` component (e.g. select an option and then applying a filter which would exclude said option would lead to the name being missing. As seen in the screenshot here: https://github.com/dhis2/event-reports-app/pull/887).

The solution was to make sure that the metadata is added to the store when options were selected plus fetching that metadata for the list of `selected` options.

---

### Known issues

-   [ ] As the `onChange` callback is fired _every_ time a change is made (even if things were only removed), the `addMetadata` action will be called unnecessarily often. However, as the action only appends metadata in a "PUT" maner, there's no impact to the actual store other than from a performance perspective.
