### PR TITLE
fix: format empty value for BOOLEAN and TRUE_ONLY

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -4,10 +4,23 @@ import i18n from '@dhis2/d2-i18n'
 import { useEffect, useState, useRef } from 'react'
 
 const VALUE_TYPE_BOOLEAN = 'BOOLEAN'
+const VALUE_TYPE_TRUE_ONLY = 'TRUE_ONLY'
 
 const booleanMap = {
     0: i18n.t('No'),
     1: i18n.t('Yes'),
+}
+
+const formatRowValue = (rowValue, valueType, rowValueItem) => {
+    switch (valueType) {
+        case VALUE_TYPE_BOOLEAN:
+        case VALUE_TYPE_TRUE_ONLY:
+            return rowValue === ''
+                ? i18n.t('Not answered')
+                : booleanMap[rowValue]
+        default:
+            return rowValueItem?.name || rowValue
+    }
 }
 
 const fetchAnalyticsData = async ({
@@ -83,10 +96,11 @@ const reduceRows = (analyticsResponse, headers) =>
                     const rowValue = row[header.index]
 
                     filteredRow.push(
-                        header.valueType === VALUE_TYPE_BOOLEAN
-                            ? booleanMap[rowValue]
-                            : analyticsResponse.metaData.items[rowValue]
-                                  ?.name || rowValue
+                        formatRowValue(
+                            rowValue,
+                            header.valueType,
+                            analyticsResponse.metaData.items[rowValue]
+                        )
                     )
                 } else {
                     // TODO solve the case of visualization.column not mapping to any response.header (ie. "pe")

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -15,9 +15,7 @@ const formatRowValue = (rowValue, valueType, rowValueItem) => {
     switch (valueType) {
         case VALUE_TYPE_BOOLEAN:
         case VALUE_TYPE_TRUE_ONLY:
-            return rowValue === ''
-                ? i18n.t('Not answered')
-                : booleanMap[rowValue]
+            return booleanMap[rowValue] || i18n.t('Not answered')
         default:
             return rowValueItem?.name || rowValue
     }


### PR DESCRIPTION
This avoids undefined or nothing to be displayed in the data table.

---

### Key features

1. avoid undefined to be shown in the data table for BOOLEAN value types
2. avoid empty cell to be shown in the data table for TRUE_ONLY value types

---

### Description

Values for both BOOLEAN and TRUE_ONLY value types can be empty.
Before `undefined` or nothing were shown as value in the data table.
`Not answered` should be shown instead to match the same text used in the condition dialog.

---

### Screenshots

Before:
<img width="402" alt="Screenshot 2022-01-19 at 14 28 20" src="https://user-images.githubusercontent.com/150978/150140089-119ceda5-78a6-4f9f-871c-5b2d7fa8e3c8.png">

After:
<img width="380" alt="Screenshot 2022-01-19 at 14 28 59" src="https://user-images.githubusercontent.com/150978/150140232-62ae8223-95fa-49c2-bba4-3ac60b48d2e9.png">

