### PR TITLE
fix: keep spinner in view when scrolling data-table

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -11,6 +11,7 @@ import {
     Pagination,
     NoticeBox,
 } from '@dhis2/ui'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import {
@@ -62,7 +63,7 @@ export const Visualization = ({
                 <NoticeBox error title={i18n.t('Could not load visualization')}>
                     {error?.message ||
                         i18n.t(
-                            'The visualization couldn’t be displayed. Try again or contact your system administrator.'
+                            "The visualization couldn't be displayed. Try again or contact your system administrator."
                         )}
                 </NoticeBox>
             </div>
@@ -80,109 +81,120 @@ export const Visualization = ({
 
     return (
         <div className={styles.wrapper}>
-            <DataTable scrollHeight="500px" width="auto">
-                <DataTableHead>
-                    <DataTableRow>
-                        {data.headers.map((header, index) =>
-                            header ? (
-                                <DataTableColumnHeader
-                                    fixed
-                                    top="0"
-                                    key={header.name}
-                                    name={header.name}
-                                    onSortIconClick={({ name, direction }) =>
-                                        setSorting({
-                                            sortField: name,
-                                            sortDirection: direction,
-                                        })
-                                    }
-                                    sortDirection={
-                                        header.name === sortField
-                                            ? sortDirection
-                                            : 'default'
-                                    }
-                                    large={large}
-                                    small={small}
-                                    className={fontSizeClass}
-                                >
-                                    {header.column}
-                                </DataTableColumnHeader>
-                            ) : (
-                                <DataTableColumnHeader
-                                    fixed
-                                    top="0"
-                                    key={`undefined_${index}`} // FIXME this is due to pe not being present in headers, needs special handling
-                                    large={large}
-                                    small={small}
-                                    className={fontSizeClass}
-                                />
-                            )
-                        )}
-                    </DataTableRow>
-                </DataTableHead>
-                {/* https://jira.dhis2.org/browse/LIBS-278 */}
-                <DataTableBody loading={fetching}>
-                    {data.rows.map((row, index) => (
-                        <DataTableRow key={index}>
-                            {row.map((value, index) => (
-                                <DataTableCell
-                                    key={index}
-                                    large={large}
-                                    small={small}
-                                    className={fontSizeClass}
-                                >
-                                    {formatValue(
-                                        value,
-                                        data.headers[index]?.valueType ||
-                                            'TEXT',
-                                        {
-                                            digitGroupSeparator:
-                                                visualization.digitGroupSeparator,
-                                            skipRounding: false, // TODO should there be an option for this?
+            <div
+                className={cx(styles.fetchIndicator, {
+                    [styles.fetching]: fetching,
+                })}
+            >
+                <DataTable scrollHeight="500px" width="auto">
+                    <DataTableHead>
+                        <DataTableRow>
+                            {data.headers.map((header, index) =>
+                                header ? (
+                                    <DataTableColumnHeader
+                                        fixed
+                                        top="0"
+                                        key={header.name}
+                                        name={header.name}
+                                        onSortIconClick={({
+                                            name,
+                                            direction,
+                                        }) =>
+                                            setSorting({
+                                                sortField: name,
+                                                sortDirection: direction,
+                                            })
                                         }
-                                    )}
-                                </DataTableCell>
-                            ))}
+                                        sortDirection={
+                                            header.name === sortField
+                                                ? sortDirection
+                                                : 'default'
+                                        }
+                                        large={large}
+                                        small={small}
+                                        className={fontSizeClass}
+                                    >
+                                        {header.column}
+                                    </DataTableColumnHeader>
+                                ) : (
+                                    <DataTableColumnHeader
+                                        fixed
+                                        top="0"
+                                        key={`undefined_${index}`} // FIXME this is due to pe not being present in headers, needs special handling
+                                        large={large}
+                                        small={small}
+                                        className={fontSizeClass}
+                                    />
+                                )
+                            )}
                         </DataTableRow>
-                    ))}
-                </DataTableBody>
-                <DataTableFoot className={styles.stickyFooter}>
-                    <DataTableRow>
-                        <DataTableCell colSpan={colSpan} staticStyle>
-                            <Pagination
-                                page={page}
-                                pageCount={data.pageCount}
-                                pageSize={pageSize}
-                                total={data.total}
-                                onPageChange={setPage}
-                                onPageSizeChange={setPageSize}
-                                pageSizeSelectText={i18n.t('Cases per page')}
-                                pageSummaryText={({
-                                    firstItem,
-                                    lastItem,
-                                    total,
-                                }) =>
-                                    i18n.t(
-                                        '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
-                                        {
-                                            firstCaseIndex: firstItem,
-                                            lastCaseIndex: lastItem,
-                                            count: total,
-                                            // FIXME does it make sense if there is only 1 case?! "1 of 1 case"
-                                            // not sure is possible to have empty string for singular with i18n
-                                            // TODO also, this string for some reason is not extracted
-                                            defaultValue:
-                                                '{{firstCaseIndex}} of {{count}} case',
-                                            defaultValue_plural:
-                                                '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
-                                        }
-                                    )
-                                }
-                            />
-                        </DataTableCell>
-                    </DataTableRow>
-                </DataTableFoot>
-            </DataTable>
+                    </DataTableHead>
+                    {/* https://jira.dhis2.org/browse/LIBS-278 */}
+                    <DataTableBody>
+                        {data.rows.map((row, index) => (
+                            <DataTableRow key={index}>
+                                {row.map((value, index) => (
+                                    <DataTableCell
+                                        key={index}
+                                        large={large}
+                                        small={small}
+                                        className={fontSizeClass}
+                                    >
+                                        {formatValue(
+                                            value,
+                                            data.headers[index]?.valueType ||
+                                                'TEXT',
+                                            {
+                                                digitGroupSeparator:
+                                                    visualization.digitGroupSeparator,
+                                                skipRounding: false, // TODO should there be an option for this?
+                                            }
+                                        )}
+                                    </DataTableCell>
+                                ))}
+                            </DataTableRow>
+                        ))}
+                    </DataTableBody>
+                    <DataTableFoot className={styles.stickyFooter}>
+                        <DataTableRow>
+                            <DataTableCell colSpan={colSpan} staticStyle>
+                                <Pagination
+                                    page={page}
+                                    pageCount={data.pageCount}
+                                    pageSize={pageSize}
+                                    total={data.total}
+                                    onPageChange={setPage}
+                                    onPageSizeChange={setPageSize}
+                                    pageSizeSelectText={i18n.t(
+                                        'Cases per page'
+                                    )}
+                                    pageSummaryText={({
+                                        firstItem,
+                                        lastItem,
+                                        total,
+                                    }) =>
+                                        i18n.t(
+                                            '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                                            {
+                                                firstCaseIndex: firstItem,
+                                                lastCaseIndex: lastItem,
+                                                count: total,
+                                                // FIXME does it make sense if there is only 1 case?! "1 of 1 case"
+                                                // not sure is possible to have empty string for singular with i18n
+                                                // TODO also, this string for some reason is not extracted
+                                                defaultValue:
+                                                    '{{firstCaseIndex}} of {{count}} case',
+                                                defaultValue_plural:
+                                                    '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                                            }
+                                        )
+                                    }
+                                />
+                            </DataTableCell>
+                        </DataTableRow>
+                    </DataTableFoot>
+                </DataTable>
+            </div>
         </div>
     )
 }

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -5,6 +5,36 @@
     align-items: flex-start;
 }
 
+.fetchIndicator {
+    position: relative;
+}
+
+.fetchIndicator.fetching::after {
+    content: '';
+    position: absolute;
+    top: calc(50% - 24px);
+    left: calc(50% - 24px);
+    width: 48px;
+    height: 48px;
+    border-width: 6px;
+    border-style: solid;
+    border-color: rgba(110, 122, 138, 0.15) rgba(110, 122, 138, 0.15)
+        rgb(20, 124, 215);
+    border-image: initial;
+    border-radius: 50%;
+    animation-duration: 1s;
+    animation-iteration-count: infinite;
+    animation-name: rotation;
+    animation-timing-function: linear;
+}
+
+.fetchIndicator.fetching tbody::before {
+    content: '';
+    position: absolute;
+    inset: 0px;
+    background-color: rgba(255, 255, 255, 0.8);
+}
+
 .stickyFooter {
     position: sticky;
     bottom: 0;
@@ -26,4 +56,13 @@
     flex: 1;
     align-self: flex-start;
     margin: 0 var(--spacers-dp12);
+}
+@keyframes rotation {
+    0% {
+        transform: rotate(0);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
 }


### PR DESCRIPTION
No issue number available

---

### Key features

1. Shows an overlay over the table-body only, as before, so users could theoretically interact with the column headers while the table data is being refreshed.
2. Shows the spinner from a wrapper element which has the same height as the table scollbox, so this will always remain in view

---

### Screenshots

<img width="1467" alt="Screenshot 2022-01-19 at 15 31 25" src="https://user-images.githubusercontent.com/353236/150151250-122cbb75-16b1-4217-b805-9f5a2a7d3be5.png">

