### PR TITLE
fix: pass headers in the analytics request DHIS2-12314

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -24,6 +24,7 @@ const formatRowValue = (rowValue, valueType, rowValueItem) => {
 const extractHeadersFromColumns = (columns) =>
     columns.reduce((headers, { dimension }) => {
         switch (dimension) {
+            // TODO remove when this is sorted out https://jira.dhis2.org/browse/TECH-869
             case 'pe':
                 break
             case 'ou':

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -80,32 +80,47 @@ const fetchAnalyticsData = async ({
     return rawResponse
 }
 
-const reduceHeaders = (analyticsResponse) =>
+const extractHeaders = (analyticsResponse) =>
     analyticsResponse.headers.map((header, index) => ({
         ...header,
         index,
     }))
 
-const reduceRows = (analyticsResponse, headers) =>
-    analyticsResponse.rows.reduce((filteredRows, row) => {
-        filteredRows.push(
-            headers.reduce((filteredRow, header) => {
-                const rowValue = row[header.index]
+const extractRows = (analyticsResponse, headers) => {
+    const filteredRows = []
 
-                filteredRow.push(
-                    formatRowValue(
-                        rowValue,
-                        header.valueType,
-                        analyticsResponse.metaData.items[rowValue]
-                    )
+    for (
+        let rowIndex = 0, rowsCount = analyticsResponse.rows.length;
+        rowIndex < rowsCount;
+        rowIndex++
+    ) {
+        const row = analyticsResponse.rows[rowIndex]
+
+        const filteredRow = []
+
+        for (
+            let headerIndex = 0, headersCount = headers.length;
+            headerIndex < headersCount;
+            headerIndex++
+        ) {
+            const header = headers[headerIndex]
+
+            const rowValue = row[header.index]
+
+            filteredRow.push(
+                formatRowValue(
+                    rowValue,
+                    header.valueType,
+                    analyticsResponse.metaData.items[rowValue]
                 )
+            )
+        }
 
-                return filteredRow
-            }, [])
-        )
+        filteredRows.push(filteredRow)
+    }
 
-        return filteredRows
-    }, [])
+    return filteredRows
+}
 
 const useAnalyticsData = ({
     visualization,
@@ -139,8 +154,8 @@ const useAnalyticsData = ({
                     sortField,
                     sortDirection,
                 })
-                const headers = reduceHeaders(analyticsResponse)
-                const rows = reduceRows(analyticsResponse, headers)
+                const headers = extractHeaders(analyticsResponse)
+                const rows = extractRows(analyticsResponse, headers)
                 const pageCount = analyticsResponse.metaData.pager.pageCount
                 const total = analyticsResponse.metaData.pager.total
 


### PR DESCRIPTION
Relates to [DHIS2-12314](https://jira.dhis2.org/browse/DHIS2-12314)

---

### Key features

1. pass the new `headers` query parameter to analytics request
2. refactor the code for generating the table content

---

### Description

The list of headers to request is directly mapped from the `visualization.columns` and in the same order, so reordering the chips in the layout allows to reorder the data in the rows.

Some columns need special handling during the mapping:
* `ou` is replaced with `ouname`
* `pe` is removed
* all date dimensions selected in the left sidebar should be added

This also simplifies populating the data table and reduces the payload in the analytics response by removing unused headers that otherwise are returned by default.

---

### TODO

-   [ ] once the date selector on the left sidebar is in place, those date fields should be added to `headers`

---

### Screenshots

Showing `ouname` in the same position as `ou`:
<img width="564" alt="Screenshot 2022-01-19 at 15 34 13" src="https://user-images.githubusercontent.com/150978/150151632-9aeccd9d-9a88-44ab-bece-91a7cbd1d12f.png">

