### PR TITLE
fix: alphanumeric case sensitive state (TECH-812)

### DIFF
--- a/src/modules/conditions.js
+++ b/src/modules/conditions.js
@@ -18,5 +18,5 @@ export const OPERATOR_NOT_EMPTY = `NE:${NULL_VALUE}`
 export const OPERATOR_IN = 'IN'
 export const OPERATOR_CONTAINS = 'LIKE'
 export const OPERATOR_NOT_CONTAINS = '!LIKE'
-export const CASE_SENSITIVE_PREFIX = 'I'
+export const CASE_INSENSITIVE_PREFIX = 'I'
 export const NOT_PREFIX = '!'


### PR DESCRIPTION
Implements [TECH-812](https://jira.dhis2.org/browse/TECH-812)

---

### Key features

1. Case sensitive checkbox default state is unchecked
2. Case sensitive checkbox now properly reflects the backend operator (unchecked -> `ILIKE`, checked -> `LIKE`)

![image](https://user-images.githubusercontent.com/12590483/150344098-406241d7-b838-422c-9439-3dab57baf965.png)

![image](https://user-images.githubusercontent.com/12590483/150344130-6ee5e849-d362-49b9-ae21-b208b23c92ca.png)

