### PR TITLE
fix: use the correct analytics endpoint based on outputType

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -2,6 +2,7 @@ import { Analytics } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { useEffect, useState, useRef } from 'react'
+import { OUTPUT_TYPE_ENROLLMENT } from '../../modules/visualization.js'
 
 const VALUE_TYPE_BOOLEAN = 'BOOLEAN'
 const VALUE_TYPE_TRUE_ONLY = 'TRUE_ONLY'
@@ -80,7 +81,15 @@ const fetchAnalyticsData = async ({
         }
     }
 
-    const rawResponse = await analyticsEngine.events.getQuery(req)
+    const analyticsApiEndpoint =
+        visualization.outputType === OUTPUT_TYPE_ENROLLMENT
+            ? 'enrollments'
+            : 'events'
+
+    // for 2.38 only /query is used (since only Line List is enabled)
+    const rawResponse = await analyticsEngine[analyticsApiEndpoint].getQuery(
+        req
+    )
 
     return rawResponse
 }

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -2,7 +2,10 @@ import { Analytics } from '@dhis2/analytics'
 import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { useEffect, useState, useRef } from 'react'
-import { OUTPUT_TYPE_ENROLLMENT } from '../../modules/visualization.js'
+import {
+    OUTPUT_TYPE_ENROLLMENT,
+    OUTPUT_TYPE_EVENT,
+} from '../../modules/visualization.js'
 
 const VALUE_TYPE_BOOLEAN = 'BOOLEAN'
 const VALUE_TYPE_TRUE_ONLY = 'TRUE_ONLY'
@@ -10,6 +13,11 @@ const VALUE_TYPE_TRUE_ONLY = 'TRUE_ONLY'
 const booleanMap = {
     0: i18n.t('No'),
     1: i18n.t('Yes'),
+}
+
+const analyticsApiEndpointMap = {
+    [OUTPUT_TYPE_ENROLLMENT]: 'enrollments',
+    [OUTPUT_TYPE_EVENT]: 'events',
 }
 
 const findOptionSetItem = (code, metaDataItems) =>
@@ -82,9 +90,7 @@ const fetchAnalyticsData = async ({
     }
 
     const analyticsApiEndpoint =
-        visualization.outputType === OUTPUT_TYPE_ENROLLMENT
-            ? 'enrollments'
-            : 'events'
+        analyticsApiEndpointMap[visualization.outputType]
 
     // for 2.38 only /query is used (since only Line List is enabled)
     const rawResponse = await analyticsEngine[analyticsApiEndpoint].getQuery(

--- a/src/modules/current.js
+++ b/src/modules/current.js
@@ -2,7 +2,7 @@ import { dimensionCreate } from '@dhis2/analytics'
 import pick from 'lodash-es/pick'
 import { BASE_FIELD_TYPE } from './fields.js'
 import { getAdaptedUiLayoutByType } from './layout.js'
-import options from './options.js'
+import { options } from './options.js'
 import { VIS_TYPE_LINE_LIST } from './visualization.js'
 
 export const getDefaultFromUi = (state, action) => {
@@ -20,6 +20,7 @@ export const getDefaultFromUi = (state, action) => {
     return {
         ...state,
         [BASE_FIELD_TYPE]: ui.type,
+        outputType: ui.input.type,
         ...getAxesFromUi(ui),
         ...getOptionsFromUi(ui),
     }

--- a/src/modules/current.js
+++ b/src/modules/current.js
@@ -5,7 +5,7 @@ import { getAdaptedUiLayoutByType } from './layout.js'
 import { options } from './options.js'
 import { VIS_TYPE_LINE_LIST } from './visualization.js'
 
-export const getDefaultFromUi = (state, action) => {
+export const getDefaultFromUi = (current, action) => {
     const ui = {
         ...action.value,
         layout: {
@@ -18,7 +18,7 @@ export const getDefaultFromUi = (state, action) => {
     }
 
     return {
-        ...state,
+        ...current,
         [BASE_FIELD_TYPE]: ui.type,
         outputType: ui.input.type,
         ...getAxesFromUi(ui),


### PR DESCRIPTION
**Requires https://github.com/dhis2/analytics/pull/1134**

---

### Key features

1. set `outputType` in current based on the Input selector
2. use the correct analytics endpoint based on `outputType`

---

### Description

Note: in 2.38 only Line List is supported

Line List:
Input: Event -> `/analytics/events/query/...`
Input: Enrollment -> `/analytics/enrollments/query/...`

Pivot Table:
Input: Event -> `/analytics/events/aggregate/...`
Input: Enrollment -> `/analytics/enrollments/aggregate/...`

---

### TODO

-   [x] update analytics dep once https://github.com/dhis2/analytics/pull/1134 is merged


### Screenshots

Example of 2 requests when toggling Input from Event to Enrollment:

<img width="835" alt="Screenshot 2022-01-20 at 16 31 53" src="https://user-images.githubusercontent.com/150978/150369952-26d60cb3-a73b-4e84-a00e-b65156e555f7.png">

