### PR TITLE
feat: forward compatibility: pe - time dimension conversion TECH-796

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -1,4 +1,4 @@
-import { formatValue } from '@dhis2/analytics'
+import { formatValue, AXIS_ID_COLUMNS } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import {
     DataTable,
@@ -13,7 +13,7 @@ import {
 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
     DISPLAY_DENSITY_COMPACT,
@@ -44,9 +44,12 @@ export const Visualization = ({
     relativePeriodDate,
 }) => {
     const maxWidth = useAvailableWidth()
+    const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
+    const defaultSortDirection = 'asc'
+
     const [{ sortField, sortDirection }, setSorting] = useState({
-        sortField: headersMap[visualization.columns[0].dimension],
-        sortDirection: 'asc',
+        sortField: headersMap[defaultSortField] || defaultSortField,
+        sortDirection: defaultSortDirection,
     })
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(100)
@@ -59,6 +62,19 @@ export const Visualization = ({
         page,
         pageSize,
     })
+
+    useEffect(() => {
+        if (visualization) {
+            const sortField = visualization[AXIS_ID_COLUMNS][0].dimension
+
+            setSorting({
+                sortField: headersMap[sortField] || sortField,
+                sortDirection: defaultSortDirection,
+            })
+            setPage(1)
+            setPageSize(100)
+        }
+    }, [visualization])
 
     if (error) {
         return (

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -21,6 +21,7 @@ import {
     FONT_SIZE_NORMAL,
     FONT_SIZE_SMALL,
 } from '../../modules/options.js'
+import { headersMap } from '../../modules/visualization.js'
 import styles from './styles/Visualization.module.css'
 import { useAnalyticsData } from './useAnalyticsData.js'
 import { useAvailableWidth } from './useAvailableWidth.js'
@@ -44,8 +45,8 @@ export const Visualization = ({
 }) => {
     const maxWidth = useAvailableWidth()
     const [{ sortField, sortDirection }, setSorting] = useState({
-        sortField: 'eventdate', // TODO get field name corresponding to visualization.sortOrder ?!
-        sortDirection: 'desc',
+        sortField: headersMap[visualization.columns[0].dimension],
+        sortDirection: 'asc',
     })
     const [page, setPage] = useState(1)
     const [pageSize, setPageSize] = useState(100)

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -3,13 +3,15 @@ import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { useEffect, useState, useRef } from 'react'
 import {
-    OUTPUT_TYPE_ENROLLMENT,
-    OUTPUT_TYPE_EVENT,
     TIME_DIMENSION_EVENT_DATE,
     TIME_DIMENSION_ENROLLMENT_DATE,
     TIME_DIMENSION_INCIDENT_DATE,
     TIME_DIMENSION_SCHEDULED_DATE,
     TIME_DIMENSION_LAST_UPDATED,
+} from '../../modules/timeDimensions.js'
+import {
+    OUTPUT_TYPE_ENROLLMENT,
+    OUTPUT_TYPE_EVENT,
     headersMap,
 } from '../../modules/visualization.js'
 

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -54,6 +54,7 @@ const isTimeDimension = (dimensionId) =>
 
 const getAdaptedVisualization = (visualization) => {
     const adaptedColumns = []
+    const adaptedRows = []
     const adaptedFilters = []
     const headers = []
     const timeDimensionParameters = {}
@@ -70,6 +71,18 @@ const getAdaptedVisualization = (visualization) => {
             : adaptedColumns.push(dimensionObj)
     })
 
+    visualization.rows.forEach((dimensionObj) => {
+        const dimensionId = dimensionObj.dimension
+
+        headers.push(headersMap[dimensionId] || dimensionId)
+
+        isTimeDimension(dimensionId)
+            ? (timeDimensionParameters[dimensionId] = dimensionObj.items?.map(
+                  (item) => item.id
+              ))
+            : adaptedRows.push(dimensionObj)
+    })
+
     visualization.filters.forEach((dimensionObj) => {
         const dimensionId = dimensionObj.dimension
 
@@ -83,6 +96,7 @@ const getAdaptedVisualization = (visualization) => {
     return {
         adaptedVisualization: {
             columns: adaptedColumns,
+            rows: adaptedRows,
             filters: adaptedFilters,
         },
         headers,
@@ -99,6 +113,7 @@ const fetchAnalyticsData = async ({
     sortField,
     sortDirection,
 }) => {
+    // XXX must be reviewed when PT comes around. Most likely LL and PT have quite different handling
     const { adaptedVisualization, headers, timeDimensionParameters } =
         getAdaptedVisualization(visualization)
 

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -58,48 +58,30 @@ const isTimeDimension = (dimensionId) =>
     ].includes(dimensionId)
 
 const getAdaptedVisualization = (visualization) => {
-    const adaptedColumns = []
-    const adaptedRows = []
-    const adaptedFilters = []
-    const headers = []
     const timeDimensionParameters = {}
 
-    const adaptDimension = ({
-        dimensionObj,
-        targetArray,
-        addToHeaders = false,
-    }) => {
-        const dimensionId = dimensionObj.dimension
+    const adaptDimensions = (dimensions) => {
+        const adaptedDimensions = []
+        dimensions.forEach((dimensionObj) => {
+            const dimensionId = dimensionObj.dimension
 
-        if (addToHeaders) {
-            headers.push(headersMap[dimensionId] || dimensionId)
-        }
-
-        isTimeDimension(dimensionId)
-            ? (timeDimensionParameters[dimensionId] = dimensionObj.items?.map(
-                  (item) => item.id
-              ))
-            : targetArray.push(dimensionObj)
+            isTimeDimension(dimensionId)
+                ? (timeDimensionParameters[dimensionId] =
+                      dimensionObj.items?.map((item) => item.id))
+                : adaptedDimensions.push(dimensionObj)
+        })
+        return adaptedDimensions
     }
 
-    visualization[AXIS_ID_COLUMNS].forEach((dimensionObj) =>
-        adaptDimension({
-            dimensionObj,
-            targetArray: adaptedColumns,
-            addToHeaders: true,
-        })
-    )
+    const adaptedColumns = adaptDimensions(visualization[AXIS_ID_COLUMNS])
+    const adaptedRows = adaptDimensions(visualization[AXIS_ID_ROWS])
+    const adaptedFilters = adaptDimensions(visualization[AXIS_ID_FILTERS])
 
-    visualization[AXIS_ID_ROWS].forEach((dimensionObj) =>
-        adaptDimension({
-            dimensionObj,
-            targetArray: adaptedRows,
-            addToHeaders: true,
-        })
-    )
-
-    visualization[AXIS_ID_FILTERS].forEach((dimensionObj) =>
-        adaptDimension({ dimensionObj, targetArray: adaptedFilters })
+    const headers = [
+        ...visualization[AXIS_ID_COLUMNS],
+        ...visualization[AXIS_ID_ROWS],
+    ].map(
+        ({ dimension: dimensionId }) => headersMap[dimensionId] || dimensionId
     )
 
     return {

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -122,7 +122,7 @@ const fetchAnalyticsData = async ({
     sortField,
     sortDirection,
 }) => {
-    // XXX must be reviewed when PT comes around. Most likely LL and PT have quite different handling
+    // TODO must be reviewed when PT comes around. Most likely LL and PT have quite different handling
     const { adaptedVisualization, headers, timeDimensionParameters } =
         getAdaptedVisualization(visualization)
 

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -5,6 +5,7 @@ import { useEffect, useState, useRef } from 'react'
 import {
     OUTPUT_TYPE_ENROLLMENT,
     OUTPUT_TYPE_EVENT,
+    headersMap,
 } from '../../modules/visualization.js'
 
 const VALUE_TYPE_BOOLEAN = 'BOOLEAN'
@@ -36,21 +37,9 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
 }
 
 const extractHeadersFromColumns = (columns) =>
-    columns.reduce((headers, { dimension }) => {
-        switch (dimension) {
-            // TODO remove when this is sorted out https://jira.dhis2.org/browse/TECH-869
-            case 'pe':
-                break
-            case 'ou':
-                headers.push('ouname')
-                break
-            default:
-                headers.push(dimension)
-                break
-        }
-
-        return headers
-    }, [])
+    columns.map(
+        ({ dimension: dimensionId }) => headersMap[dimensionId] || dimensionId
+    )
 
 const fetchAnalyticsData = async ({
     analyticsEngine,

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -3,12 +3,12 @@ import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { useEffect, useState, useRef } from 'react'
 import {
-    TIME_DIMENSION_EVENT_DATE,
-    TIME_DIMENSION_ENROLLMENT_DATE,
-    TIME_DIMENSION_INCIDENT_DATE,
-    TIME_DIMENSION_SCHEDULED_DATE,
-    TIME_DIMENSION_LAST_UPDATED,
-} from '../../modules/timeDimensions.js'
+    DIMENSION_TYPE_EVENT_DATE,
+    DIMENSION_TYPE_ENROLLMENT_DATE,
+    DIMENSION_TYPE_INCIDENT_DATE,
+    DIMENSION_TYPE_SCHEDULED_DATE,
+    DIMENSION_TYPE_LAST_UPDATED,
+} from '../../modules/dimensionTypes.js'
 import {
     OUTPUT_TYPE_ENROLLMENT,
     OUTPUT_TYPE_EVENT,
@@ -45,11 +45,11 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
 
 const isTimeDimension = (dimensionId) =>
     [
-        TIME_DIMENSION_EVENT_DATE,
-        TIME_DIMENSION_ENROLLMENT_DATE,
-        TIME_DIMENSION_INCIDENT_DATE,
-        TIME_DIMENSION_SCHEDULED_DATE,
-        TIME_DIMENSION_LAST_UPDATED,
+        DIMENSION_TYPE_EVENT_DATE,
+        DIMENSION_TYPE_ENROLLMENT_DATE,
+        DIMENSION_TYPE_INCIDENT_DATE,
+        DIMENSION_TYPE_SCHEDULED_DATE,
+        DIMENSION_TYPE_LAST_UPDATED,
     ].includes(dimensionId)
 
 const getAdaptedVisualization = (visualization) => {

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -7,16 +7,16 @@ import {
     VIS_TYPE_PIVOT_TABLE,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import {
-    TIME_DIMENSION_EVENT_DATE,
-    TIME_DIMENSION_ENROLLMENT_DATE,
-    TIME_DIMENSION_INCIDENT_DATE,
-    TIME_DIMENSION_SCHEDULED_DATE,
-    TIME_DIMENSION_LAST_UPDATED,
-} from '../modules/timeDimensions.js'
 import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
-import { DIMENSION_TYPE_DATA_ELEMENT } from './dimensionTypes.js'
+import {
+    DIMENSION_TYPE_DATA_ELEMENT,
+    DIMENSION_TYPE_EVENT_DATE,
+    DIMENSION_TYPE_ENROLLMENT_DATE,
+    DIMENSION_TYPE_INCIDENT_DATE,
+    DIMENSION_TYPE_SCHEDULED_DATE,
+    DIMENSION_TYPE_LAST_UPDATED,
+} from './dimensionTypes.js'
 import { default as options } from './options.js'
 
 export const OUTPUT_TYPE_EVENT = 'EVENT'
@@ -28,11 +28,11 @@ export const headersMap = {
     eventStatus: 'eventstatus',
     storedBy: 'storedby',
     lastUpdatedBy: 'lastupdatedby',
-    [TIME_DIMENSION_EVENT_DATE]: 'eventdate',
-    [TIME_DIMENSION_ENROLLMENT_DATE]: 'enrollmentdate',
-    [TIME_DIMENSION_INCIDENT_DATE]: 'incidentdate',
-    [TIME_DIMENSION_SCHEDULED_DATE]: 'scheduleddate',
-    [TIME_DIMENSION_LAST_UPDATED]: 'lastupdated',
+    [DIMENSION_TYPE_EVENT_DATE]: 'eventdate',
+    [DIMENSION_TYPE_ENROLLMENT_DATE]: 'enrollmentdate',
+    [DIMENSION_TYPE_INCIDENT_DATE]: 'incidentdate',
+    [DIMENSION_TYPE_SCHEDULED_DATE]: 'scheduleddate',
+    [DIMENSION_TYPE_LAST_UPDATED]: 'lastupdated',
 }
 
 export const outputTypeMap = {
@@ -49,8 +49,8 @@ export const outputTypeMap = {
 }
 
 export const outputTypeTimeDimensionMap = {
-    [OUTPUT_TYPE_EVENT]: TIME_DIMENSION_EVENT_DATE,
-    [OUTPUT_TYPE_ENROLLMENT]: TIME_DIMENSION_ENROLLMENT_DATE,
+    [OUTPUT_TYPE_EVENT]: DIMENSION_TYPE_EVENT_DATE,
+    [OUTPUT_TYPE_ENROLLMENT]: DIMENSION_TYPE_ENROLLMENT_DATE,
 }
 
 export const transformVisualization = (visualization) => ({

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -15,6 +15,41 @@ import { default as options } from './options.js'
 export const OUTPUT_TYPE_EVENT = 'EVENT'
 export const OUTPUT_TYPE_ENROLLMENT = 'ENROLLMENT'
 
+export const TIME_DIMENSION_EVENT_DATE = 'eventDate'
+export const TIME_DIMENSION_ENROLLMENT_DATE = 'enrollmentDate'
+export const TIME_DIMENSION_INCIDENT_DATE = 'incidentDate'
+export const TIME_DIMENSION_SCHEDULED_DATE = 'scheduledDate'
+export const TIME_DIMENSION_LAST_UPDATED = 'lastUpdated'
+
+export const headersMap = {
+    ou: 'ouname',
+    programStatus: 'programstatus',
+    eventStatus: 'eventstatus',
+    storedBy: 'storedby',
+    lastUpdatedBy: 'lastupdatedby',
+    [TIME_DIMENSION_EVENT_DATE]: 'eventdate',
+    [TIME_DIMENSION_ENROLLMENT_DATE]: 'enrollmentdate',
+    [TIME_DIMENSION_INCIDENT_DATE]: 'incidentdate',
+    [TIME_DIMENSION_SCHEDULED_DATE]: 'scheduleddate',
+    [TIME_DIMENSION_LAST_UPDATED]: 'lastupdated',
+}
+
+export const visTypeMap = {
+    [VIS_TYPE_LINE_LIST]: {
+        name: i18n.t('Line list'),
+        description: 'TEXT description for Line list',
+        icon: PivotTableIcon,
+        disabled: false,
+    },
+    [VIS_TYPE_PIVOT_TABLE]: {
+        name: i18n.t('Pivot table'),
+        description: 'TEXT description for Pivot table',
+        icon: PivotTableIcon,
+        disabled: true,
+        disabledText: i18n.t('Pivot tables are not supported by this app yet'),
+    },
+}
+
 export const outputTypeMap = {
     [OUTPUT_TYPE_EVENT]: {
         name: i18n.t('Event'),
@@ -45,8 +80,8 @@ const transformDimension = (dimensionObj, outputType) => {
     // TODO waiting for the time dimensions work to be completed.
     // most likely there are going to be constants for these time dimensions
     const timeDimensionMap = {
-        [OUTPUT_TYPE_EVENT]: 'eventDate',
-        [OUTPUT_TYPE_ENROLLMENT]: 'enrollmentDate',
+        [OUTPUT_TYPE_EVENT]: TIME_DIMENSION_EVENT_DATE,
+        [OUTPUT_TYPE_ENROLLMENT]: TIME_DIMENSION_ENROLLMENT_DATE,
     }
 
     if (dimensionObj.dimensionType === 'PROGRAM_DATA_ELEMENT') {

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -7,6 +7,14 @@ import {
     VIS_TYPE_PIVOT_TABLE,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
+import PivotTableIcon from '../assets/PivotTableIcon.js'
+import {
+    TIME_DIMENSION_EVENT_DATE,
+    TIME_DIMENSION_ENROLLMENT_DATE,
+    TIME_DIMENSION_INCIDENT_DATE,
+    TIME_DIMENSION_SCHEDULED_DATE,
+    TIME_DIMENSION_LAST_UPDATED,
+} from '../modules/timeDimensions.js'
 import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from './dimensionTypes.js'
@@ -14,12 +22,6 @@ import { default as options } from './options.js'
 
 export const OUTPUT_TYPE_EVENT = 'EVENT'
 export const OUTPUT_TYPE_ENROLLMENT = 'ENROLLMENT'
-
-export const TIME_DIMENSION_EVENT_DATE = 'eventDate'
-export const TIME_DIMENSION_ENROLLMENT_DATE = 'enrollmentDate'
-export const TIME_DIMENSION_INCIDENT_DATE = 'incidentDate'
-export const TIME_DIMENSION_SCHEDULED_DATE = 'scheduledDate'
-export const TIME_DIMENSION_LAST_UPDATED = 'lastUpdated'
 
 export const headersMap = {
     ou: 'ouname',

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -30,9 +30,15 @@ export const outputTypeMap = {
 
 export const transformVisualization = (visualization) => ({
     ...visualization,
-    [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map(transformDimension),
-    [AXIS_ID_ROWS]: visualization[AXIS_ID_ROWS].map(transformDimension),
-    [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map(transformDimension),
+    [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map((dimensionObj) =>
+        transformDimension(dimensionObj, visualization.outputType)
+    ),
+    [AXIS_ID_ROWS]: visualization[AXIS_ID_ROWS].map((dimensionObj) =>
+        transformDimension(dimensionObj, visualization.outputType)
+    ),
+    [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map((dimensionObj) =>
+        transformDimension(dimensionObj, visualization.outputType)
+    ),
 })
 
 const transformDimension = (dimensionObj, outputType) => {

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -48,36 +48,37 @@ export const outputTypeMap = {
     },
 }
 
+export const outputTypeTimeDimensionMap = {
+    [OUTPUT_TYPE_EVENT]: TIME_DIMENSION_EVENT_DATE,
+    [OUTPUT_TYPE_ENROLLMENT]: TIME_DIMENSION_ENROLLMENT_DATE,
+}
+
 export const transformVisualization = (visualization) => ({
     ...visualization,
     [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map((dimensionObj) =>
-        transformDimension(dimensionObj, visualization.outputType)
+        transformDimension(dimensionObj, visualization)
     ),
     [AXIS_ID_ROWS]: visualization[AXIS_ID_ROWS].map((dimensionObj) =>
-        transformDimension(dimensionObj, visualization.outputType)
+        transformDimension(dimensionObj, visualization)
     ),
     [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map((dimensionObj) =>
-        transformDimension(dimensionObj, visualization.outputType)
+        transformDimension(dimensionObj, visualization)
     ),
 })
 
-const transformDimension = (dimensionObj, outputType) => {
-    // TODO waiting for the time dimensions work to be completed.
-    // most likely there are going to be constants for these time dimensions
-    const timeDimensionMap = {
-        [OUTPUT_TYPE_EVENT]: TIME_DIMENSION_EVENT_DATE,
-        [OUTPUT_TYPE_ENROLLMENT]: TIME_DIMENSION_ENROLLMENT_DATE,
-    }
-
+const transformDimension = (dimensionObj, { outputType, type }) => {
     if (dimensionObj.dimensionType === 'PROGRAM_DATA_ELEMENT') {
         return {
             ...dimensionObj,
             dimensionType: DIMENSION_TYPE_DATA_ELEMENT,
         }
-    } else if (dimensionObj.dimension === DIMENSION_ID_PERIOD) {
+    } else if (
+        dimensionObj.dimension === DIMENSION_ID_PERIOD &&
+        type === VIS_TYPE_LINE_LIST
+    ) {
         return {
             ...dimensionObj,
-            dimension: timeDimensionMap[outputType],
+            dimension: outputTypeTimeDimensionMap[outputType],
         }
     } else {
         return dimensionObj

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -7,7 +7,6 @@ import {
     VIS_TYPE_PIVOT_TABLE,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import PivotTableIcon from '../assets/PivotTableIcon.js'
 import {
     TIME_DIMENSION_EVENT_DATE,
     TIME_DIMENSION_ENROLLMENT_DATE,
@@ -34,22 +33,6 @@ export const headersMap = {
     [TIME_DIMENSION_INCIDENT_DATE]: 'incidentdate',
     [TIME_DIMENSION_SCHEDULED_DATE]: 'scheduleddate',
     [TIME_DIMENSION_LAST_UPDATED]: 'lastupdated',
-}
-
-export const visTypeMap = {
-    [VIS_TYPE_LINE_LIST]: {
-        name: i18n.t('Line list'),
-        description: 'TEXT description for Line list',
-        icon: PivotTableIcon,
-        disabled: false,
-    },
-    [VIS_TYPE_PIVOT_TABLE]: {
-        name: i18n.t('Pivot table'),
-        description: 'TEXT description for Pivot table',
-        icon: PivotTableIcon,
-        disabled: true,
-        disabledText: i18n.t('Pivot tables are not supported by this app yet'),
-    },
 }
 
 export const outputTypeMap = {

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -55,35 +55,39 @@ export const outputTypeTimeDimensionMap = {
 
 export const transformVisualization = (visualization) => ({
     ...visualization,
-    [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map((dimensionObj) =>
-        transformDimension(dimensionObj, visualization)
+    [AXIS_ID_COLUMNS]: transformDimensions(
+        visualization[AXIS_ID_COLUMNS],
+        visualization
     ),
-    [AXIS_ID_ROWS]: visualization[AXIS_ID_ROWS].map((dimensionObj) =>
-        transformDimension(dimensionObj, visualization)
+    [AXIS_ID_ROWS]: transformDimensions(
+        visualization[AXIS_ID_ROWS],
+        visualization
     ),
-    [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map((dimensionObj) =>
-        transformDimension(dimensionObj, visualization)
+    [AXIS_ID_FILTERS]: transformDimensions(
+        visualization[AXIS_ID_FILTERS],
+        visualization
     ),
 })
 
-const transformDimension = (dimensionObj, { outputType, type }) => {
-    if (dimensionObj.dimensionType === 'PROGRAM_DATA_ELEMENT') {
-        return {
-            ...dimensionObj,
-            dimensionType: DIMENSION_TYPE_DATA_ELEMENT,
+const transformDimensions = (dimensions, { outputType, type }) =>
+    dimensions.map((dimensionObj) => {
+        if (dimensionObj.dimensionType === 'PROGRAM_DATA_ELEMENT') {
+            return {
+                ...dimensionObj,
+                dimensionType: DIMENSION_TYPE_DATA_ELEMENT,
+            }
+        } else if (
+            dimensionObj.dimension === DIMENSION_ID_PERIOD &&
+            type === VIS_TYPE_LINE_LIST
+        ) {
+            return {
+                ...dimensionObj,
+                dimension: outputTypeTimeDimensionMap[outputType],
+            }
+        } else {
+            return dimensionObj
         }
-    } else if (
-        dimensionObj.dimension === DIMENSION_ID_PERIOD &&
-        type === VIS_TYPE_LINE_LIST
-    ) {
-        return {
-            ...dimensionObj,
-            dimension: outputTypeTimeDimensionMap[outputType],
-        }
-    } else {
-        return dimensionObj
-    }
-}
+    })
 
 export const visTypes = [
     { type: VIS_TYPE_LINE_LIST },

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -1,6 +1,8 @@
 import {
     AXIS_ID_COLUMNS,
+    AXIS_ID_ROWS,
     AXIS_ID_FILTERS,
+    DIMENSION_ID_PERIOD,
     VIS_TYPE_LINE_LIST,
     VIS_TYPE_PIVOT_TABLE,
 } from '@dhis2/analytics'
@@ -26,25 +28,35 @@ export const outputTypeMap = {
     },
 }
 
-export const transformProgramDataElement = (visualization) => {
-    const replaceProgramDataElement = (dimension) =>
-        dimension.dimensionType === 'PROGRAM_DATA_ELEMENT'
-            ? { ...dimension, dimensionType: DIMENSION_TYPE_DATA_ELEMENT }
-            : dimension
+export const transformVisualization = (visualization) => ({
+    ...visualization,
+    [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map(transformDimension),
+    [AXIS_ID_ROWS]: visualization[AXIS_ID_ROWS].map(transformDimension),
+    [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map(transformDimension),
+})
 
-    return {
-        ...visualization,
-        [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map(
-            replaceProgramDataElement
-        ),
-        [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map(
-            replaceProgramDataElement
-        ),
+const transformDimension = (dimensionObj, outputType) => {
+    // TODO waiting for the time dimensions work to be completed.
+    // most likely there are going to be constants for these time dimensions
+    const timeDimensionMap = {
+        [OUTPUT_TYPE_EVENT]: 'eventDate',
+        [OUTPUT_TYPE_ENROLLMENT]: 'enrollmentDate',
+    }
+
+    if (dimensionObj.dimensionType === 'PROGRAM_DATA_ELEMENT') {
+        return {
+            ...dimensionObj,
+            dimensionType: DIMENSION_TYPE_DATA_ELEMENT,
+        }
+    } else if (dimensionObj.dimension === DIMENSION_ID_PERIOD) {
+        return {
+            ...dimensionObj,
+            dimension: timeDimensionMap[outputType],
+        }
+    } else {
+        return dimensionObj
     }
 }
-
-export const transformVisualization = (visualization) =>
-    transformProgramDataElement(visualization)
 
 export const visTypes = [
     { type: VIS_TYPE_LINE_LIST },


### PR DESCRIPTION
Implements [TECH-869](https://jira.dhis2.org/browse/TECH-869) and [TECH-960](https://jira.dhis2.org/browse/TECH-960)

---

### Key features

1. convert `pe` dimension to a time dimension when opening a "old format" AO [(TECH-869)](https://jira.dhis2.org/browse/TECH-869)
2. format column values to pass to `headers` in the analytics request ([TECH-960](https://jira.dhis2.org/browse/TECH-960))
3. pass the time dimensions as arguments in the analytics request
4. set default sorting to first column ascending

---

### Description

The new time dimensions that can be added to Columns/Filters require special handling in the analytics request.
1. they need to be passed in `headers` like the other dimensions but lowercased
2. they need to be passed as query arguments in the analytics request instead of as `dimension` argument

---

### TODO

-   [x] use constants for the time dimension names
-   [ ] refactor some code? move `isTimeDimension` and `getAdaptedVisualization` to `modules/visualization`?

---

### Known issues

-   [x] backend is not ready with the support for the new time dimensions so the analytics request resolves in a conflict due to missing start/end dates
-   [ ] Layout is empty in LL due to this code returning `false` because `layout` has the replaced period dimension but there isn't a correspondent entry in `metaData` (ie. `enrollmentDate` in layout and `pe` in metaData)
