### PR TITLE
feat: visualization scrollbox auto-width

### DIFF
--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -43,16 +43,15 @@
 }
 
 .mainRight {
-    flex: 1 1 0%;
-    max-width: 380px;
+    width: 380px;
     background-color: #f0f2f4;
     overflow-y: auto;
     overflow-x: hidden;
     transform: scaleX(1);
-    transition: max-width 200ms ease-out;
+    transition: width 200ms ease-out;
 }
 .mainRight.hidden {
-    max-width: 0;
+    width: 0;
 }
 /* Main canvas */
 

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -23,6 +23,7 @@ import {
 } from '../../modules/options.js'
 import styles from './styles/Visualization.module.css'
 import { useAnalyticsData } from './useAnalyticsData.js'
+import { useAvailableWidth } from './useAvailableWidth.js'
 
 const getFontSizeClass = (fontSize) => {
     switch (fontSize) {
@@ -41,6 +42,7 @@ export const Visualization = ({
     onResponseReceived,
     relativePeriodDate,
 }) => {
+    const maxWidth = useAvailableWidth()
     const [{ sortField, sortDirection }, setSorting] = useState({
         sortField: 'eventdate', // TODO get field name corresponding to visualization.sortOrder ?!
         sortDirection: 'desc',
@@ -86,7 +88,11 @@ export const Visualization = ({
                     [styles.fetching]: fetching,
                 })}
             >
-                <DataTable scrollHeight="500px" width="auto">
+                <DataTable
+                    scrollHeight="500px"
+                    width="auto"
+                    scrollWidth={maxWidth}
+                >
                     <DataTableHead>
                         <DataTableRow>
                             {data.headers.map((header, index) =>

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -35,6 +35,10 @@
     background-color: rgba(255, 255, 255, 0.8);
 }
 
+.fetchIndicator :global(.tablescrollbox) {
+    transition: max-width 200ms ease-out;
+}
+
 .stickyFooter {
     position: sticky;
     bottom: 0;

--- a/src/components/Visualization/useAvailableWidth.js
+++ b/src/components/Visualization/useAvailableWidth.js
@@ -1,0 +1,28 @@
+import { useSelector } from 'react-redux'
+import {
+    sGetUiShowDetailsPanel,
+    sGetUiShowAccessoryPanel,
+} from '../../reducers/ui.js'
+
+const LEFT_SIDEBARS_WIDTH = 260
+const RIGHT_SIDEBAR_WIDTH = 380
+const PADDING = 2 * 4
+const BORDER = 2 * 1
+
+export const useAvailableWidth = () => {
+    const leftOpen = useSelector(sGetUiShowAccessoryPanel)
+    const rightOpen = useSelector(sGetUiShowDetailsPanel)
+
+    let availableWidth =
+        window.innerWidth - LEFT_SIDEBARS_WIDTH - PADDING - BORDER
+
+    if (leftOpen) {
+        availableWidth -= LEFT_SIDEBARS_WIDTH
+    }
+
+    if (rightOpen) {
+        availableWidth -= RIGHT_SIDEBAR_WIDTH
+    }
+
+    return `${availableWidth}px`
+}


### PR DESCRIPTION
No issue number available

---

### Key features

1. Limit table scrollbox width to available width
2. Animate scrollbox width with the same animation as the panels so everything looks smooth

---

### Screenshots
<img width="1387" alt="Screenshot 2022-01-25 at 13 27 46" src="https://user-images.githubusercontent.com/353236/150977085-4f9b1c3e-20ac-46be-9280-264b55593226.png">


