### PR TITLE
fix: only dispatch once in metadata middleware

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-01-26T15:16:16.072Z\n"
-"PO-Revision-Date: 2022-01-26T15:16:16.072Z\n"
+"POT-Creation-Date: 2022-01-28T14:22:26.535Z\n"
+"PO-Revision-Date: 2022-01-28T14:22:26.535Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -107,6 +107,9 @@ msgstr "Loading..."
 
 msgid "Choose a set of options"
 msgstr "Choose a set of options"
+
+msgid "Choose options"
+msgstr "Choose options"
 
 msgid "Available options"
 msgstr "Available options"

--- a/src/middleware/metadata.js
+++ b/src/middleware/metadata.js
@@ -3,16 +3,22 @@ import { acAddMetadata } from '../actions/metadata.js'
 export default ({ dispatch }) =>
     (next) =>
     (action) => {
-        if (
-            typeof action.metadata === 'object' &&
-            !Array.isArray(action.metadata)
-        ) {
-            dispatch(acAddMetadata(action.metadata))
-        } else if (
-            typeof action.metadata === 'object' &&
-            Array.isArray(action.metadata)
-        ) {
-            action.metadata.forEach((item) => dispatch(acAddMetadata(item)))
+        if (typeof action.metadata === 'object') {
+            if (Array.isArray(action.metadata)) {
+                dispatch(
+                    acAddMetadata(
+                        action.metadata.reduce(
+                            (meta, obj) => ({
+                                ...meta,
+                                ...obj,
+                            }),
+                            {}
+                        )
+                    )
+                )
+            } else {
+                dispatch(acAddMetadata(action.metadata))
+            }
         }
 
         next(action)


### PR DESCRIPTION
When an array is picked up by the metadata middleware it no longer dispatches every item, but creates a single object with all the keys and dispatches once.

This PR also removes the doubled up `typeof` check.

Before (this example is from loading a saved visualization):

![Screenshot from 2022-01-28 14-08-00](https://user-images.githubusercontent.com/1010094/151566807-7147c139-43b7-4727-ba31-3b2d74d50b1b.png)

After:

![Screenshot from 2022-01-28 15-41-08](https://user-images.githubusercontent.com/1010094/151566841-5517d0a6-da4c-4a17-8019-7c05929fa2e2.png)




