### PR TITLE
fix: convert PROGRAM_DATA_ELEMENT to DATA_ELEMENT dimensions (TECH-964)

### DIFF
--- a/src/api/legendSets.js
+++ b/src/api/legendSets.js
@@ -1,6 +1,8 @@
-const TYPE_PA = 'PROGRAM_ATTRIBUTE'
-const TYPE_DE = 'PROGRAM_DATA_ELEMENT'
-const TYPE_PI = 'PROGRAM_INDICATOR'
+import {
+    DIMENSION_TYPE_DE,
+    DIMENSION_TYPE_PA,
+    DIMENSION_TYPE_PI,
+} from '../modules/visualization.js'
 
 const dataElementsQuery = {
     resource: 'dataElements',
@@ -60,13 +62,13 @@ export const apiFetchLegendSetsByDimension = async ({
 }) => {
     let query
     switch (dimensionType) {
-        case TYPE_DE:
+        case DIMENSION_TYPE_DE:
             query = dataElementsQuery
             break
-        case TYPE_PA:
+        case DIMENSION_TYPE_PA:
             query = trackedEntityAttributesQuery
             break
-        case TYPE_PI:
+        case DIMENSION_TYPE_PI:
             query = programIndicatorsQuery
             break
         default:

--- a/src/api/legendSets.js
+++ b/src/api/legendSets.js
@@ -1,7 +1,7 @@
 import {
-    DIMENSION_TYPE_DE,
-    DIMENSION_TYPE_PA,
-    DIMENSION_TYPE_PI,
+    DIMENSION_TYPE_DATA_ELEMENT,
+    DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
+    DIMENSION_TYPE_PROGRAM_INDICATOR,
 } from '../modules/visualization.js'
 
 const dataElementsQuery = {
@@ -62,13 +62,13 @@ export const apiFetchLegendSetsByDimension = async ({
 }) => {
     let query
     switch (dimensionType) {
-        case DIMENSION_TYPE_DE:
+        case DIMENSION_TYPE_DATA_ELEMENT:
             query = dataElementsQuery
             break
-        case DIMENSION_TYPE_PA:
+        case DIMENSION_TYPE_PROGRAM_ATTRIBUTE:
             query = trackedEntityAttributesQuery
             break
-        case DIMENSION_TYPE_PI:
+        case DIMENSION_TYPE_PROGRAM_INDICATOR:
             query = programIndicatorsQuery
             break
         default:

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -23,6 +23,7 @@ import {
 import { EVENT_TYPE } from '../modules/dataStatistics.js'
 import history from '../modules/history.js'
 import { getParentGraphMapFromVisualization } from '../modules/ui.js'
+import { transformVisualization } from '../modules/visualization.js'
 import { sGetCurrent } from '../reducers/current.js'
 import { sGetIsVisualizationLoading } from '../reducers/loader.js'
 import { sGetUiShowDetailsPanel } from '../reducers/ui.js'
@@ -232,9 +233,11 @@ const App = ({
     }, [])
 
     useEffect(() => {
-        const visualization = data?.eventVisualization
+        if (data?.eventVisualization) {
+            const visualization = transformVisualization(
+                data.eventVisualization
+            )
 
-        if (visualization) {
             addParentGraphMap(getParentGraphMapFromVisualization(visualization))
             setVisualization(visualization)
             setCurrent(visualization)

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -10,6 +10,7 @@ import {
     parseConditionsArrayToString,
     parseConditionsStringToArray,
 } from '../../../modules/conditions.js'
+import { DIMENSION_TYPE_PROGRAM_INDICATOR } from '../../../modules/visualization.js'
 import { sGetMetadata } from '../../../reducers/metadata.js'
 import { sGetSettingsDisplayNameProperty } from '../../../reducers/settings.js'
 import {
@@ -52,7 +53,6 @@ const VALUE_TYPE_DATE = 'DATE'
 const VALUE_TYPE_TIME = 'TIME'
 const VALUE_TYPE_DATETIME = 'DATETIME'
 const VALUE_TYPE_ORGANISATION_UNIT = 'ORGANISATION_UNIT'
-const DIMENSION_TYPE_PROGRAM_INDICATOR = 'PROGRAM_INDICATOR'
 
 const NUMERIC_TYPES = [
     VALUE_TYPE_NUMBER,

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsFilter.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsFilter.js
@@ -3,15 +3,16 @@ import { SingleSelect, SingleSelectOption, Input } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useSelector } from 'react-redux'
-import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
+import {
+    DIMENSION_TYPE_ALL,
+    DIMENSION_TYPE_DATA_ELEMENT,
+    DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
+    DIMENSION_TYPE_PROGRAM_INDICATOR,
+    OUTPUT_TYPE_ENROLLMENT,
+} from '../../../modules/visualization.js'
 import { sGetUiInputType } from '../../../reducers/ui.js'
 import styles from './ProgramDimensionsFilter.module.css'
 import { StageSelect } from './StageSelect.js'
-
-const DIMENSION_TYPE_ALL = 'ALL'
-const DIMENSION_TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
-const DIMENSION_TYPE_PROGRAM_ATTRIBUTE = 'PROGRAM_ATTRIBUTE'
-const DIMENSION_TYPE_PROGRAM_INDICATOR = 'PROGRAM_INDICATOR'
 
 const ProgramDimensionsFilter = ({
     program,
@@ -71,10 +72,4 @@ ProgramDimensionsFilter.propTypes = {
     setSearchTerm: PropTypes.func,
 }
 
-export {
-    ProgramDimensionsFilter,
-    DIMENSION_TYPE_ALL,
-    DIMENSION_TYPE_DATA_ELEMENT,
-    DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
-    DIMENSION_TYPE_PROGRAM_INDICATOR,
-}
+export { ProgramDimensionsFilter }

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -11,16 +11,16 @@ import {
     acClearUiProgram,
 } from '../../../actions/ui.js'
 import { useDebounce } from '../../../modules/utils.js'
-import { OUTPUT_TYPE_EVENT } from '../../../modules/visualization.js'
+import {
+    DIMENSION_TYPE_ALL,
+    OUTPUT_TYPE_EVENT,
+} from '../../../modules/visualization.js'
 import {
     sGetUiInputType,
     sGetUiProgramId,
     sGetUiProgramStage,
 } from '../../../reducers/ui.js'
-import {
-    ProgramDimensionsFilter,
-    DIMENSION_TYPE_ALL,
-} from './ProgramDimensionsFilter.js'
+import { ProgramDimensionsFilter } from './ProgramDimensionsFilter.js'
 import { ProgramDimensionsList } from './ProgramDimensionsList.js'
 import styles from './ProgramDimensionsPanel.module.css'
 import { ProgramSelect } from './ProgramSelect.js'

--- a/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
@@ -1,14 +1,12 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import { useEffect, useReducer, useCallback } from 'react'
 import {
+    DIMENSION_TYPE_ALL,
+    DIMENSION_TYPE_DATA_ELEMENT,
     OUTPUT_TYPE_EVENT,
     OUTPUT_TYPE_ENROLLMENT,
 } from '../../../modules/visualization.js'
 import { DIMENSION_LIST_FIELDS } from '../DimensionsList/index.js'
-import {
-    DIMENSION_TYPE_ALL,
-    DIMENSION_TYPE_DATA_ELEMENT,
-} from './ProgramDimensionsFilter.js'
 
 const ACTIONS_RESET = 'RESET'
 const ACTIONS_INIT = 'INIT'

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -5,9 +5,10 @@ import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
 import { default as options } from './options.js'
 
-export const DIMENSION_TYPE_DE = 'DATA_ELEMENT'
-export const DIMENSION_TYPE_PA = 'PROGRAM_ATTRIBUTE'
-export const DIMENSION_TYPE_PI = 'PROGRAM_INDICATOR'
+export const DIMENSION_TYPE_ALL = 'ALL'
+export const DIMENSION_TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
+export const DIMENSION_TYPE_PROGRAM_ATTRIBUTE = 'PROGRAM_ATTRIBUTE'
+export const DIMENSION_TYPE_PROGRAM_INDICATOR = 'PROGRAM_INDICATOR'
 
 export const VIS_TYPE_PIVOT_TABLE = 'PIVOT_TABLE'
 export const VIS_TYPE_LINE_LIST = 'LINE_LIST'
@@ -47,7 +48,7 @@ export const outputTypeMap = {
 export const transformProgramDataElement = (visualization) => {
     const replaceProgramDataElement = (dimension) =>
         dimension.dimensionType === 'PROGRAM_DATA_ELEMENT'
-            ? { ...dimension, dimensionType: DIMENSION_TYPE_DE }
+            ? { ...dimension, dimensionType: DIMENSION_TYPE_DATA_ELEMENT }
             : dimension
 
     return {

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -1,8 +1,13 @@
+import { AXIS_ID_COLUMNS, AXIS_ID_FILTERS } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import PivotTableIcon from '../assets/PivotTableIcon.js'
 import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
 import { default as options } from './options.js'
+
+export const DIMENSION_TYPE_DE = 'DATA_ELEMENT'
+export const DIMENSION_TYPE_PA = 'PROGRAM_ATTRIBUTE'
+export const DIMENSION_TYPE_PI = 'PROGRAM_INDICATOR'
 
 export const VIS_TYPE_PIVOT_TABLE = 'PIVOT_TABLE'
 export const VIS_TYPE_LINE_LIST = 'LINE_LIST'
@@ -38,6 +43,26 @@ export const outputTypeMap = {
         description: i18n.t('Programs track enrollments across time'),
     },
 }
+
+export const transformProgramDataElement = (visualization) => {
+    const replaceProgramDataElement = (dimension) =>
+        dimension.dimensionType === 'PROGRAM_DATA_ELEMENT'
+            ? { ...dimension, dimensionType: DIMENSION_TYPE_DE }
+            : dimension
+
+    return {
+        ...visualization,
+        [AXIS_ID_COLUMNS]: visualization[AXIS_ID_COLUMNS].map(
+            replaceProgramDataElement
+        ),
+        [AXIS_ID_FILTERS]: visualization[AXIS_ID_FILTERS].map(
+            replaceProgramDataElement
+        ),
+    }
+}
+
+export const transformVisualization = (visualization) =>
+    transformProgramDataElement(visualization)
 
 export const getVisualizationFromCurrent = (current) => {
     const visualization = Object.assign({}, current)


### PR DESCRIPTION
Implements [TECH-964](https://jira.dhis2.org/browse/TECH-964)

---

### Key features

1. convert PROGRAM_DATA_ELEMENT to DATA_ELEMENT dimensions

---

### Description

When opening an AO, some dimensions have `PROGRAM_DATA_ELEMENT` `dimensionType` which causes conflicts in the new ER app.
This PR converts all such dimensions in `columns` and `filters` before storing `current` in the Redux store.

### TODO

- [ ] convert also `rows`? (Currently we don't handle rows due to Line List ER being the only ones opened/created in the new ER app)

### Screenshots

Before:
<img width="822" alt="Screenshot 2022-01-31 at 14 35 37" src="https://user-images.githubusercontent.com/150978/151803156-6428eb59-c856-431c-87e3-1d19095c4f48.png">

After:
<img width="840" alt="Screenshot 2022-01-31 at 14 32 03" src="https://user-images.githubusercontent.com/150978/151802599-012d1aff-daf1-4ce9-9bdf-f5e677357125.png">
