### PR TITLE
fix: prevent clearing program and stage after loading saved visualization

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -18,7 +18,7 @@ import {
     SET_UI_INPUT,
     UPDATE_UI_PROGRAM_ID,
     UPDATE_UI_PROGRAM_STAGE_ID,
-    CLEAR_UI_PROGRAM_ID,
+    CLEAR_UI_PROGRAM,
     CLEAR_UI_STAGE_ID,
 } from '../reducers/ui.js'
 
@@ -27,8 +27,8 @@ export const acSetUiInput = (value) => ({
     value,
 })
 
-export const acClearUiProgramId = () => ({
-    type: CLEAR_UI_PROGRAM_ID,
+export const acClearUiProgram = () => ({
+    type: CLEAR_UI_PROGRAM,
 })
 
 export const acClearUiStageId = () => ({
@@ -47,10 +47,15 @@ export const acUpdateUiProgramStageId = (value, metadata) => ({
     metadata,
 })
 
+export const tSetUiInput = (value) => (dispatch) => {
+    dispatch(acClearUiProgram())
+    dispatch(acSetUiInput(value))
+}
+
 export const tSetUiProgram =
     ({ programId, stageId, metadata }) =>
-    async (dispatch) => {
-        dispatch(acClearUiProgramId())
+    (dispatch) => {
+        dispatch(acClearUiProgram())
         programId && dispatch(acUpdateUiProgramId(programId, metadata))
         stageId && dispatch(acUpdateUiProgramStageId(stageId))
     }

--- a/src/components/MainSidebar/InputPanel/InputPanel.js
+++ b/src/components/MainSidebar/InputPanel/InputPanel.js
@@ -2,7 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { acSetUiInput } from '../../../actions/ui.js'
+import { tSetUiInput } from '../../../actions/ui.js'
 import {
     OUTPUT_TYPE_EVENT,
     OUTPUT_TYPE_ENROLLMENT,
@@ -29,7 +29,7 @@ const InputPanel = ({ visible }) => {
 
     const selectedInput = useSelector(sGetUiInput)
     const dispatch = useDispatch()
-    const setSelectedInput = (input) => dispatch(acSetUiInput(input))
+    const setSelectedInput = (input) => dispatch(tSetUiInput(input))
 
     return (
         <div className={styles.container}>

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -5,12 +5,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import {
-    tSetUiProgram,
-    acUpdateUiProgramStageId,
-    acClearUiProgramId,
-    acClearUiStageId,
-} from '../../../actions/ui.js'
+import { tSetUiProgram, acUpdateUiProgramStageId } from '../../../actions/ui.js'
 import { DIMENSION_TYPE_ALL } from '../../../modules/dimensionTypes.js'
 import { useDebounce } from '../../../modules/utils.js'
 import {
@@ -55,18 +50,6 @@ const ProgramDimensionsPanel = ({ visible }) => {
     const inputType = useSelector(sGetUiInputType)
     const selectedProgramId = useSelector(sGetUiProgramId)
     const selectedStageId = useSelector(sGetUiProgramStageId)
-    const setSelectedProgramId = (programId) =>
-        dispatch(
-            tSetUiProgram({
-                programId,
-                metadata: {
-                    [programId]: filteredPrograms.find(
-                        ({ id }) => id === programId
-                    ),
-                },
-            })
-        )
-
     const { fetching, error, data, refetch, called } = useDataQuery(query, {
         lazy: true,
     })
@@ -91,6 +74,20 @@ const ProgramDimensionsPanel = ({ visible }) => {
         inputType === OUTPUT_TYPE_EVENT
             ? selectedProgram && selectedStageId
             : !!selectedProgram
+    const setSelectedProgramId = (programId) => {
+        if (programId !== selectedProgramId) {
+            dispatch(
+                tSetUiProgram({
+                    programId,
+                    metadata: {
+                        [programId]: filteredPrograms.find(
+                            ({ id }) => id === programId
+                        ),
+                    },
+                })
+            )
+        }
+    }
 
     useEffect(() => {
         if (visible && !called) {
@@ -99,15 +96,6 @@ const ProgramDimensionsPanel = ({ visible }) => {
     }, [visible, called])
 
     useEffect(() => {
-        // Clear everything when user changes input type
-        dispatch(acClearUiProgramId())
-        setSearchTerm('')
-        setDimensionType(DIMENSION_TYPE_ALL)
-    }, [inputType])
-
-    useEffect(() => {
-        // Clear everything but program itself when user switches program
-        dispatch(acClearUiStageId())
         setSearchTerm('')
         setDimensionType(DIMENSION_TYPE_ALL)
     }, [inputType, selectedProgramId])

--- a/src/reducers/__tests__/ui.spec.js
+++ b/src/reducers/__tests__/ui.spec.js
@@ -3,7 +3,7 @@ import { OUTPUT_TYPE_EVENT } from '../../modules/visualization.js'
 import reducer, {
     DEFAULT_UI,
     SET_UI_INPUT,
-    CLEAR_UI_PROGRAM_ID,
+    CLEAR_UI_PROGRAM,
     UPDATE_UI_PROGRAM_ID,
     UPDATE_UI_PROGRAM_STAGE_ID,
     SET_UI_REPETITION,
@@ -46,7 +46,7 @@ describe('reducer: store.ui', () => {
         })
     })
 
-    describe(`reducer: ${CLEAR_UI_PROGRAM_ID}`, () => {
+    describe(`reducer: ${CLEAR_UI_PROGRAM}`, () => {
         const prevState = {
             program: {
                 id: 'P',
@@ -55,7 +55,7 @@ describe('reducer: store.ui', () => {
         }
 
         const clearProgramAction = {
-            type: CLEAR_UI_PROGRAM_ID,
+            type: CLEAR_UI_PROGRAM,
         }
 
         it('clears the selected program', () => {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -10,7 +10,7 @@ import { getAdaptedUiByType, getUiFromVisualization } from '../modules/ui.js'
 import { OUTPUT_TYPE_EVENT } from '../modules/visualization.js'
 
 export const SET_UI_INPUT = 'SET_UI_INPUT'
-export const CLEAR_UI_PROGRAM_ID = 'CLEAR_UI_PROGRAM_ID'
+export const CLEAR_UI_PROGRAM = 'CLEAR_UI_PROGRAM'
 export const CLEAR_UI_STAGE_ID = 'CLEAR_UI_STAGE_ID'
 export const UPDATE_UI_PROGRAM_ID = 'UPDATE_UI_PROGRAM_ID'
 export const UPDATE_UI_PROGRAM_STAGE_ID = 'UPDATE_UI_PROGRAM_STAGE_ID'
@@ -104,7 +104,7 @@ export default (state = EMPTY_UI, action) => {
                 input: action.value,
             }
         }
-        case CLEAR_UI_PROGRAM_ID: {
+        case CLEAR_UI_PROGRAM: {
             return {
                 ...state,
                 program: EMPTY_UI.program,


### PR DESCRIPTION
Additional fix to [DHIS2-874](https://jira.dhis2.org/browse/DHIS2-DHIS2-874)

---

### Key features

1. Program and stage are not longer cleared after loading a saved visualisation
2. `CLEAR_UI_PROGRAM_ID` was renamed to `CLEAR_UI_PROGRAM`, because it doesn't just clear the program's `id` field, but also the `stageId`.

---

### Screenshots

<img width="517" alt="Screenshot 2022-02-07 at 11 56 18" src="https://user-images.githubusercontent.com/353236/152775975-0762b296-a8d6-47f0-ac1a-1e20f92a7d98.png">
Action sequence after the fix: no more `CLEAR_UI_PROGRAM` and `CLEAR_UI_STAGE` after `SET_UI_FROM_VISUALIZATION`
