### PR TITLE
chore: fix prgram stage filter

### DIFF
--- a/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
@@ -3,24 +3,29 @@ import { SingleSelect, SingleSelectOption } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { tSetUiStage } from '../../../actions/ui.js'
+import { tSetUiStage, acClearUiStageId } from '../../../actions/ui.js'
 import { sGetUiProgramStageId } from '../../../reducers/ui.js'
 
-const STAGE_ALL = 'STAGE_ALL'
+export const STAGE_ALL = 'STAGE_ALL'
 
 const StageSelect = ({ optional, stages }) => {
     const dispatch = useDispatch()
     const selectedStageId = useSelector(sGetUiProgramStageId)
     const onChange = ({ selected: stageId }) => {
-        const stage = stages.find(({ id }) => id === stageId)
-        dispatch(tSetUiStage(stage))
+        if (stageId === STAGE_ALL) {
+            dispatch(acClearUiStageId())
+        } else {
+            const stage = stages.find(({ id }) => id === stageId)
+            dispatch(tSetUiStage(stage))
+        }
     }
+    const selected = selectedStageId || (optional && STAGE_ALL)
 
     return (
         <SingleSelect
             prefix={i18n.t('Stage')}
             dense
-            selected={selectedStageId}
+            selected={selected}
             onChange={onChange}
         >
             {optional && (

--- a/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { tSetUiStage, acClearUiStageId } from '../../../actions/ui.js'
 import { sGetUiProgramStageId } from '../../../reducers/ui.js'
 
-export const STAGE_ALL = 'STAGE_ALL'
+const STAGE_ALL = 'STAGE_ALL'
 
 const StageSelect = ({ optional, stages }) => {
     const dispatch = useDispatch()

--- a/src/components/MainSidebar/ProgramDimensionsPanel/__tests__/useProgramDimensions.spec.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/__tests__/useProgramDimensions.spec.js
@@ -74,7 +74,7 @@ describe('ER > Dimensions > useProgramDimensions > createDimensionsQuery', () =>
                 searchTerm: '',
                 dimensionType: 'DATA_ELEMENT',
             })
-            expect(actual.params.filter).toContain('id:like:TEST')
+            expect(actual.params.filter).toContain('id:startsWith:TEST')
         })
     })
     describe('params for both input types', () => {

--- a/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
@@ -97,7 +97,6 @@ const createDimensionsQuery = ({
         inputType === OUTPUT_TYPE_ENROLLMENT &&
         dimensionType === DIMENSION_TYPE_DATA_ELEMENT
     ) {
-        console.log('stageId', stageId)
         // This works because data element IDs have the following notation:
         // `${programStageId}.${dataElementId}`
         params.filter.push(`id:startsWith:${stageId}`)

--- a/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
@@ -97,9 +97,10 @@ const createDimensionsQuery = ({
         inputType === OUTPUT_TYPE_ENROLLMENT &&
         dimensionType === DIMENSION_TYPE_DATA_ELEMENT
     ) {
+        console.log('stageId', stageId)
         // This works because data element IDs have the following notation:
         // `${programStageId}.${dataElementId}`
-        params.filter.push(`id:like:${stageId}`)
+        params.filter.push(`id:startsWith:${stageId}`)
     }
 
     /*


### PR DESCRIPTION
Implements issue nr not available

---

### Key features

1. Use `id:startsWith:<ID>` instead of `id:like:<ID>` to filter data element dimensions
2. Ensure the stage ID is not added to the global store when `STAGE_ALL` is selected

---

### Known issues

-   [ ] We are sending the correct query params to the server but the filter still doesn't seem to be working.

---
