### PR TITLE
fix: prefix programStageId to dimensionId in analytics headers

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -93,8 +93,10 @@ const getAdaptedVisualization = (visualization) => {
     const headers = [
         ...visualization[AXIS_ID_COLUMNS],
         ...visualization[AXIS_ID_ROWS],
-    ].map(
-        ({ dimension: dimensionId }) => headersMap[dimensionId] || dimensionId
+    ].map(({ dimension, programStage }) =>
+        programStage?.id
+            ? `${programStage.id}.${dimension}`
+            : headersMap[dimension] || dimension
     )
 
     return {


### PR DESCRIPTION
### Key features

1. add programStageId to dimensionId passed in analytics headers

---

### Description

This is required for the analytics request to work.
The format is the same as what is used for passing `dimensions`: `<programStageId>.<dimensionId>`

---

### Screenshots

Before:
<img width="422" alt="Screenshot 2022-02-17 at 10 19 46" src="https://user-images.githubusercontent.com/150978/154444547-486018ee-6ec6-4214-98b4-e1ed96845a67.png">

which causes this error:
<img width="1185" alt="Screenshot 2022-02-17 at 10 20 08" src="https://user-images.githubusercontent.com/150978/154444615-12e0d2f8-ea16-445d-b21e-b295dc980cd9.png">

After:
<img width="425" alt="Screenshot 2022-02-17 at 10 05 04" src="https://user-images.githubusercontent.com/150978/154442039-9c714e3b-a631-4515-b6c1-94b864e6193b.png">

