### PR TITLE
fix: remove console warnings due to component props

### DIFF
--- a/src/components/Dialogs/DialogManager.js
+++ b/src/components/Dialogs/DialogManager.js
@@ -22,9 +22,9 @@ const isDynamicDimension = (type) =>
 
 const DialogManager = () => {
     const dispatch = useDispatch()
-    const dimension = useSelector((state) => {
-        return sGetMetadata(state)[sGetUiActiveModalDialog(state)]
-    })
+    const dimension = useSelector(
+        (state) => sGetMetadata(state)[sGetUiActiveModalDialog(state)]
+    )
 
     const onClose = () => dispatch(acSetUiOpenDimensionModal(null))
 

--- a/src/components/Dialogs/DialogManager.js
+++ b/src/components/Dialogs/DialogManager.js
@@ -1,7 +1,6 @@
 import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
-import PropTypes from 'prop-types'
 import React from 'react'
-import { connect } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
 import {
     DIMENSION_TYPE_CATEGORY,
@@ -21,8 +20,13 @@ const isDynamicDimension = (type) =>
         DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET,
     ].includes(type)
 
-const DialogManager = ({ dimension, changeDialog }) => {
-    const onClose = () => changeDialog(null)
+const DialogManager = () => {
+    const dispatch = useDispatch()
+    const dimension = useSelector((state) => {
+        return sGetMetadata(state)[sGetUiActiveModalDialog(state)]
+    })
+
+    const onClose = () => dispatch(acSetUiOpenDimensionModal(null))
 
     if (isDynamicDimension(dimension?.dimensionType)) {
         return <DynamicDimension dimension={dimension} onClose={onClose} />
@@ -40,19 +44,4 @@ const DialogManager = ({ dimension, changeDialog }) => {
     }
 }
 
-DialogManager.propTypes = {
-    changeDialog: PropTypes.func.isRequired,
-    dimension: PropTypes.object.isRequired,
-}
-
-DialogManager.defaultProps = {
-    rootOrgUnits: [],
-}
-
-const mapStateToProps = (state) => ({
-    dimension: sGetMetadata(state)[sGetUiActiveModalDialog(state)],
-})
-
-export default connect(mapStateToProps, {
-    changeDialog: acSetUiOpenDimensionModal,
-})(DialogManager)
+export default DialogManager

--- a/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeListItem.js
+++ b/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeListItem.js
@@ -43,7 +43,7 @@ VisualizationTypeListItem.propTypes = {
     onClick: PropTypes.func,
 }
 
-VisualizationTypeListItem.defaultValues = {
+VisualizationTypeListItem.defaultProps = {
     onClick: Function.prototype,
 }
 

--- a/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeListItem.js
+++ b/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeListItem.js
@@ -43,4 +43,8 @@ VisualizationTypeListItem.propTypes = {
     onClick: PropTypes.func,
 }
 
+VisualizationTypeListItem.defaultValues = {
+    onClick: Function.prototype,
+}
+
 export default VisualizationTypeListItem

--- a/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeSelector.js
+++ b/src/components/Toolbar/VisualizationTypeSelector/VisualizationTypeSelector.js
@@ -30,7 +30,7 @@ const VisualizationTypeSelector = ({ visualizationType }) => {
                 label={visTypeDisplayNames[type]}
                 description={visTypeDescriptions[type]}
                 isSelected={type === visualizationType}
-                onClick={!disabled && handleListItemClick(type)}
+                onClick={!disabled ? handleListItemClick(type) : null}
                 disabled={disabled}
             />
         )


### PR DESCRIPTION
I also took the opportunity to switch DialogManager from `connect` to `useDispatch` and `useSelector`.
And `rootOrgUnits` was not in use