### PR TITLE
feat: time dimensions dialog

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-20T08:52:08.816Z\n"
-"PO-Revision-Date: 2022-02-20T08:52:08.816Z\n"
+"POT-Creation-Date: 2022-02-21T08:15:47.708Z\n"
+"PO-Revision-Date: 2022-02-21T08:15:47.708Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -117,11 +117,6 @@ msgstr "Choose options"
 msgid "Hide"
 msgstr "Hide"
 
-<<<<<<< HEAD
-=======
-msgid "Update"
-msgstr "Update"
-
 msgid "Choose from presets"
 msgstr "Choose from presets"
 
@@ -137,7 +132,6 @@ msgstr "Start date"
 msgid "End date"
 msgstr "End date"
 
->>>>>>> 12af591 (feat: add time dimension dialog ui (not connected to the store))
 msgid "No items selected"
 msgstr "No items selected"
 

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -117,6 +117,27 @@ msgstr "Choose options"
 msgid "Hide"
 msgstr "Hide"
 
+<<<<<<< HEAD
+=======
+msgid "Update"
+msgstr "Update"
+
+msgid "Choose from presets"
+msgstr "Choose from presets"
+
+msgid "Define start - end dates"
+msgstr "Define start - end dates"
+
+msgid "Start and end dates are inclusive and will be included in the outputs."
+msgstr "Start and end dates are inclusive and will be included in the outputs."
+
+msgid "Start date"
+msgstr "Start date"
+
+msgid "End date"
+msgstr "End date"
+
+>>>>>>> 12af591 (feat: add time dimension dialog ui (not connected to the store))
 msgid "No items selected"
 msgstr "No items selected"
 

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -157,9 +157,10 @@ export const acSetUiOpenDimensionModal = (value, metadata) => ({
     metadata,
 })
 
-export const acSetUiItems = (value) => ({
+export const acSetUiItems = (value, metadata) => ({
     type: SET_UI_ITEMS,
     value,
+    metadata,
 })
 
 export const acAddParentGraphMap = (value) => ({

--- a/src/components/Dialogs/DialogManager.js
+++ b/src/components/Dialogs/DialogManager.js
@@ -32,8 +32,6 @@ const DialogManager = () => {
 
     const onClose = () => dispatch(acSetUiOpenDimensionModal(null))
 
-    console.log('checkme', dimension?.dimensionType, DIMENSION_TYPE_PERIOD)
-
     if (isDynamicDimension(dimension?.dimensionType)) {
         return <DynamicDimension dimension={dimension} onClose={onClose} />
     }

--- a/src/components/Dialogs/DialogManager.js
+++ b/src/components/Dialogs/DialogManager.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
 import {
+    DIMENSION_TYPE_PERIOD,
     DIMENSION_TYPE_CATEGORY,
     DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET,
     DIMENSION_TYPE_EVENT_STATUS,
@@ -14,6 +15,7 @@ import { sGetUiActiveModalDialog } from '../../reducers/ui.js'
 import ConditionsManager from './Conditions/ConditionsManager.js'
 import DynamicDimension from './DynamicDimension.js'
 import FixedDimension from './FixedDimension.js'
+import PeriodDimension from './PeriodDimension/index.js'
 
 const isDynamicDimension = (type) =>
     [
@@ -30,8 +32,13 @@ const DialogManager = () => {
 
     const onClose = () => dispatch(acSetUiOpenDimensionModal(null))
 
+    console.log('checkme', dimension?.dimensionType, DIMENSION_TYPE_PERIOD)
+
     if (isDynamicDimension(dimension?.dimensionType)) {
         return <DynamicDimension dimension={dimension} onClose={onClose} />
+    }
+    if (dimension?.dimensionType === DIMENSION_TYPE_PERIOD) {
+        return <PeriodDimension dimension={dimension} onClose={onClose} />
     }
     switch (dimension?.id) {
         case DIMENSION_TYPE_PROGRAM_STATUS:
@@ -39,7 +46,6 @@ const DialogManager = () => {
         case DIMENSION_ID_ORGUNIT: {
             return <FixedDimension dimension={dimension} onClose={onClose} />
         }
-        // TODO: case DIMENSION_ID_PERIOD:
         default: {
             return dimension?.id ? (
                 <ConditionsManager dimension={dimension} onClose={onClose} />

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -74,8 +74,8 @@ export const PeriodDimension = ({ dimension, onClose }) => {
         selectedIds
             .filter((id) => !isStartEndDate(id))
             /*
-             * TODO: it should be able to fetch the names from the metadata store
-             * once the backend starts returning period dimension metadata
+             * TODO: it should be possible to fetch the names from the metadata
+             * store once the backend starts returning period dimension metadata
              */
             .map((id) => ({ id, name: id }))
     )
@@ -85,7 +85,6 @@ export const PeriodDimension = ({ dimension, onClose }) => {
     )
 
     const primaryOnClick = () => {
-        // first add to metadata and ui
         const metadata = presets.reduce((acc, preset) => {
             acc[preset.id] = preset
             return acc
@@ -102,10 +101,9 @@ export const PeriodDimension = ({ dimension, onClose }) => {
             }
             uiItems.itemIds.push(startEndDate)
         }
+
         dispatch(acSetUiItems(uiItems, metadata))
-        // then update current
         dispatch(tSetCurrentFromUi())
-        // and finally close modal
         onClose()
     }
 

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -1,0 +1,107 @@
+import { PeriodDimension as BasePeriodDimension } from '@dhis2/analytics'
+import i18n from '@dhis2/d2-i18n'
+import { SegmentedControl } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import { connect } from 'react-redux'
+import { tSetCurrentFromUi } from '../../../actions/current.js'
+import { acAddMetadata } from '../../../actions/metadata.js'
+import {
+    sGetDimensionIdsFromLayout,
+    sGetUiItemsByDimension,
+} from '../../../reducers/ui.js'
+import DimensionModal from '../DimensionModal.js'
+import styles from './PeriodDimension.module.css'
+import { StartEndDate } from './StartEndDate.js'
+
+export const OPTION_PRESETS = 'PRESETS'
+export const OPTION_START_END_DATES = 'START_END_DATES'
+const segmentedControlOptions = [
+    { label: i18n.t('Choose from presets'), value: OPTION_PRESETS },
+    {
+        label: i18n.t('Define start - end dates'),
+        value: OPTION_START_END_DATES,
+    },
+]
+
+export const PeriodDimension = ({
+    addMetadata,
+    dimension,
+    isInLayout,
+    selectedIds,
+    onClose,
+    onUpdate,
+}) => {
+    const [entryMethod, setEntryMethod] = useState(OPTION_PRESETS)
+    const [startEndDate, setStartEndDate] = useState('')
+    const selectedPeriods = selectedIds.map((id) => ({ id, name: id }))
+
+    // console.log(
+    //     addMetadata,
+    //     dimension,
+    //     isInLayout,
+    //     selectedIds,
+    //     setUiItems,
+    //     onClose,
+    //     onUpdate
+    // )
+    const primaryOnClick = () => console.log('clicka')
+
+    return dimension ? (
+        <DimensionModal
+            dataTest={'period-dimension-modal'}
+            isInLayout={isInLayout}
+            onClose={onClose}
+            onUpdate={primaryOnClick}
+            title={dimension.name}
+        >
+            <SegmentedControl
+                options={segmentedControlOptions}
+                selected={entryMethod}
+                onChange={({ value }) => setEntryMethod(value)}
+            ></SegmentedControl>
+            <div className={styles.entry}>
+                {entryMethod === OPTION_PRESETS && (
+                    <BasePeriodDimension
+                        selectedPeriods={selectedPeriods}
+                        onSelect={(payload) => console.log(payload)}
+                    />
+                )}
+                {entryMethod === OPTION_START_END_DATES && (
+                    <StartEndDate
+                        value={startEndDate}
+                        setValue={setStartEndDate}
+                    />
+                )}
+            </div>
+        </DimensionModal>
+    ) : null
+}
+
+SegmentedControl.propTypes = {
+    /** An option to select; should match the `value` property of the option to be selected */
+    selected: PropTypes.string.isRequired,
+    /** Called with the signature `({ value: string }, event)` */
+    onChange: PropTypes.func.isRequired,
+}
+
+PeriodDimension.propTypes = {
+    addMetadata: PropTypes.func.isRequired,
+    dimension: PropTypes.object.isRequired,
+    isInLayout: PropTypes.bool.isRequired,
+    selectedIds: PropTypes.array.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
+}
+
+const mapStateToProps = (state, ownProps) => ({
+    isInLayout: sGetDimensionIdsFromLayout(state).includes(
+        ownProps.dimension?.id
+    ),
+    selectedIds: sGetUiItemsByDimension(state, ownProps.dimension?.id) || [],
+})
+
+export default connect(mapStateToProps, {
+    onUpdate: tSetCurrentFromUi,
+    addMetadata: acAddMetadata,
+})(PeriodDimension)

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.module.css
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.module.css
@@ -1,0 +1,5 @@
+.entry {
+    border-top: 1px solid var(--colors-grey400);
+    margin-top: var(--spacers-dp8);
+    padding-top: var(--spacers-dp12);
+}

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -1,16 +1,25 @@
 import i18n from '@dhis2/d2-i18n'
 import { Field, IconArrowRight16, InputField, colors } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styles from './StartEndDate.module.css'
 
 export const StartEndDate = ({ value, setValue }) => {
     const [startDateStr, endDateStr] = value ? value.split('_') : []
+    const [startDate, setStartDate] = useState(startDateStr)
+    const [endDate, setEndDate] = useState(endDateStr)
+
+    useEffect(() => {
+        if (startDate && endDate) {
+            setValue(`${startDate}_${endDate}`)
+        }
+    }, [startDate, endDate])
+
     const onStartDateChange = ({ value }) => {
-        setValue(`${value}_${endDateStr}`)
+        setStartDate(value)
     }
     const onEndDateChange = ({ value }) => {
-        setValue(`${startDateStr}_${value}`)
+        setEndDate(value)
     }
 
     return (
@@ -21,7 +30,7 @@ export const StartEndDate = ({ value, setValue }) => {
         >
             <div className={styles.row}>
                 <InputField
-                    value={startDateStr}
+                    value={startDate}
                     type="date"
                     onChange={onStartDateChange}
                     label={i18n.t('Start date')}
@@ -31,7 +40,7 @@ export const StartEndDate = ({ value, setValue }) => {
                     <IconArrowRight16 color={colors.grey500} />
                 </div>
                 <InputField
-                    value={endDateStr}
+                    value={endDate}
                     type="date"
                     onChange={onEndDateChange}
                     label={i18n.t('End date')}

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.js
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.js
@@ -1,0 +1,47 @@
+import i18n from '@dhis2/d2-i18n'
+import { Field, IconArrowRight16, InputField, colors } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styles from './StartEndDate.module.css'
+
+export const StartEndDate = ({ value, setValue }) => {
+    const [startDateStr, endDateStr] = value ? value.split('_') : []
+    const onStartDateChange = ({ value }) => {
+        setValue(`${value}_${endDateStr}`)
+    }
+    const onEndDateChange = ({ value }) => {
+        setValue(`${startDateStr}_${value}`)
+    }
+
+    return (
+        <Field
+            helpText={i18n.t(
+                'Start and end dates are inclusive and will be included in the outputs.'
+            )}
+        >
+            <div className={styles.row}>
+                <InputField
+                    value={startDateStr}
+                    type="date"
+                    onChange={onStartDateChange}
+                    label={i18n.t('Start date')}
+                    inputWidth="200px"
+                />
+                <div className={styles.icon}>
+                    <IconArrowRight16 color={colors.grey500} />
+                </div>
+                <InputField
+                    value={endDateStr}
+                    type="date"
+                    onChange={onEndDateChange}
+                    label={i18n.t('End date')}
+                    inputWidth="200px"
+                />
+            </div>
+        </Field>
+    )
+}
+StartEndDate.propTypes = {
+    setValue: PropTypes.func.isRequired,
+    value: PropTypes.string.isRequired,
+}

--- a/src/components/Dialogs/PeriodDimension/StartEndDate.module.css
+++ b/src/components/Dialogs/PeriodDimension/StartEndDate.module.css
@@ -1,0 +1,11 @@
+.row {
+    display: flex;
+    gap: var(--spacers-dp4);
+    align-items: flex-end;
+}
+.icon {
+    flex-grow: 0;
+    height: 40px;
+    display: flex;
+    align-items: center;
+}

--- a/src/components/Dialogs/PeriodDimension/index.js
+++ b/src/components/Dialogs/PeriodDimension/index.js
@@ -1,2 +1,2 @@
-import PeriodDimension from './PeriodDimension.js'
+import { PeriodDimension } from './PeriodDimension.js'
 export default PeriodDimension

--- a/src/components/Dialogs/PeriodDimension/index.js
+++ b/src/components/Dialogs/PeriodDimension/index.js
@@ -1,0 +1,2 @@
+import PeriodDimension from './PeriodDimension.js'
+export default PeriodDimension

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -134,7 +134,6 @@ const fetchAnalyticsData = async ({
         .withOutputType(visualization.outputType)
         .withPageSize(pageSize)
         .withPage(page)
-        .withIncludeMetadataDetails(true)
 
     if (relativePeriodDate) {
         req = req.withRelativePeriodDate(relativePeriodDate)

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -134,6 +134,7 @@ const fetchAnalyticsData = async ({
         .withOutputType(visualization.outputType)
         .withPageSize(pageSize)
         .withPage(page)
+        .withIncludeMetadataDetails(true)
 
     if (relativePeriodDate) {
         req = req.withRelativePeriodDate(relativePeriodDate)


### PR DESCRIPTION
Implements [DHIS2-TECH-963](https://jira.dhis2.org/browse/DHIS2-TECH-963)

---

### Key features

1. Opens period dimension modal when clicking on time dimension items
2. Updates `metadata`, `ui` and `current` store with selected items

---

### TODO

-   [ ] Implement proper display names for items that are preselected when a saved visualization is loaded

---

### Known issues

-   [ ] Preselected items show their ID as name because the backend currently doesn't return metadata for selected period dimensions (see [this Slack thread](https://dhis2.slack.com/archives/G3TL0J145/p1645099048878379?thread_ts=1645093552.964819&cid=G3TL0J145))

---

### Screenshots

<img width="827" alt="Screenshot 2022-02-18 at 10 10 50" src="https://user-images.githubusercontent.com/353236/154652810-f2fe6695-2eb5-4a78-b617-ec1182c6b891.png">
<img width="828" alt="Screenshot 2022-02-18 at 10 11 02" src="https://user-images.githubusercontent.com/353236/154652831-4a2bee40-086c-449f-8dd0-03a052d47317.png">

