### PR TITLE
fix: createdB lastUpdatedBy dimension handling for analytics

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -16,11 +16,11 @@ import {
     DIMENSION_TYPE_INCIDENT_DATE,
     DIMENSION_TYPE_SCHEDULED_DATE,
     DIMENSION_TYPE_LAST_UPDATED,
+    DIMENSION_TYPE_CREATED_BY,
+    DIMENSION_TYPE_LAST_UPDATED_BY,
 } from '../../modules/dimensionTypes.js'
 import history from '../../modules/history.js'
 import {
-    DIMENSION_ID_CREATED_BY,
-    DIMENSION_ID_LAST_UPDATED_BY,
     OUTPUT_TYPE_ENROLLMENT,
     OUTPUT_TYPE_EVENT,
     headersMap,
@@ -41,8 +41,8 @@ const analyticsApiEndpointMap = {
 }
 
 const excludedDimensions = [
-    DIMENSION_ID_CREATED_BY,
-    DIMENSION_ID_LAST_UPDATED_BY,
+    DIMENSION_TYPE_CREATED_BY,
+    DIMENSION_TYPE_LAST_UPDATED_BY,
 ]
 
 const findOptionSetItem = (code, metaDataItems) =>

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -19,6 +19,8 @@ import {
 } from '../../modules/dimensionTypes.js'
 import history from '../../modules/history.js'
 import {
+    DIMENSION_ID_CREATED_BY,
+    DIMENSION_ID_LAST_UPDATED_BY,
     OUTPUT_TYPE_ENROLLMENT,
     OUTPUT_TYPE_EVENT,
     headersMap,
@@ -37,6 +39,11 @@ const analyticsApiEndpointMap = {
     [OUTPUT_TYPE_ENROLLMENT]: 'enrollments',
     [OUTPUT_TYPE_EVENT]: 'events',
 }
+
+const excludedDimensions = [
+    DIMENSION_ID_CREATED_BY,
+    DIMENSION_ID_LAST_UPDATED_BY,
+]
 
 const findOptionSetItem = (code, metaDataItems) =>
     Object.values(metaDataItems).find((item) => item.code === code)
@@ -78,7 +85,7 @@ const getAdaptedVisualization = (visualization) => {
                 parameters[dimensionId] = dimensionObj.items?.map(
                     (item) => item.id
                 )
-            } else {
+            } else if (!excludedDimensions.includes(dimensionId)) {
                 adaptedDimensions.push(dimensionObj)
             }
         })

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -4,6 +4,7 @@ import {
     AXIS_ID_FILTERS,
     VIS_TYPE_LINE_LIST,
     VIS_TYPE_PIVOT_TABLE,
+    DIMENSION_ID_ORGUNIT,
     DIMENSION_ID_PERIOD,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
@@ -33,6 +34,9 @@ export const STATUS_SKIPPED = 'SKIPPED'
 export const OUTPUT_TYPE_EVENT = 'EVENT'
 export const OUTPUT_TYPE_ENROLLMENT = 'ENROLLMENT'
 
+export const DIMENSION_ID_CREATED_BY = 'createdBy'
+export const DIMENSION_ID_LAST_UPDATED_BY = 'lastUpdatedBy'
+
 export const statusNames = {
     [STATUS_ACTIVE]: i18n.t('Active'),
     [STATUS_CANCELLED]: i18n.t('Cancelled'),
@@ -43,11 +47,11 @@ export const statusNames = {
 }
 
 export const headersMap = {
-    ou: 'ouname',
+    [DIMENSION_ID_ORGUNIT]: 'ouname',
     [DIMENSION_TYPE_PROGRAM_STATUS]: 'programstatus',
     [DIMENSION_TYPE_EVENT_STATUS]: 'eventstatus',
-    createdBy: 'createdby',
-    [DIMENSION_TYPE_LAST_UPDATED_BY]: 'lastupdatedby',
+    [DIMENSION_ID_CREATED_BY]: 'createdbydisplayname',
+    [DIMENSION_ID_LAST_UPDATED_BY]: 'lastupdatedbydisplayname',
     [DIMENSION_TYPE_EVENT_DATE]: 'eventdate',
     [DIMENSION_TYPE_ENROLLMENT_DATE]: 'enrollmentdate',
     [DIMENSION_TYPE_INCIDENT_DATE]: 'incidentdate',

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -12,6 +12,7 @@ import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
 import {
     DIMENSION_TYPE_PERIOD,
+    DIMENSION_TYPE_CREATED_BY,
     DIMENSION_TYPE_DATA_ELEMENT,
     DIMENSION_TYPE_EVENT_STATUS,
     DIMENSION_TYPE_EVENT_DATE,
@@ -19,8 +20,8 @@ import {
     DIMENSION_TYPE_INCIDENT_DATE,
     DIMENSION_TYPE_SCHEDULED_DATE,
     DIMENSION_TYPE_LAST_UPDATED,
-    DIMENSION_TYPE_PROGRAM_STATUS,
     DIMENSION_TYPE_LAST_UPDATED_BY,
+    DIMENSION_TYPE_PROGRAM_STATUS,
 } from './dimensionTypes.js'
 import { default as options } from './options.js'
 
@@ -33,9 +34,6 @@ export const STATUS_SKIPPED = 'SKIPPED'
 
 export const OUTPUT_TYPE_EVENT = 'EVENT'
 export const OUTPUT_TYPE_ENROLLMENT = 'ENROLLMENT'
-
-export const DIMENSION_ID_CREATED_BY = 'createdBy'
-export const DIMENSION_ID_LAST_UPDATED_BY = 'lastUpdatedBy'
 
 export const statusNames = {
     [STATUS_ACTIVE]: i18n.t('Active'),
@@ -50,8 +48,8 @@ export const headersMap = {
     [DIMENSION_ID_ORGUNIT]: 'ouname',
     [DIMENSION_TYPE_PROGRAM_STATUS]: 'programstatus',
     [DIMENSION_TYPE_EVENT_STATUS]: 'eventstatus',
-    [DIMENSION_ID_CREATED_BY]: 'createdbydisplayname',
-    [DIMENSION_ID_LAST_UPDATED_BY]: 'lastupdatedbydisplayname',
+    [DIMENSION_TYPE_CREATED_BY]: 'createdbydisplayname',
+    [DIMENSION_TYPE_LAST_UPDATED_BY]: 'lastupdatedbydisplayname',
     [DIMENSION_TYPE_EVENT_DATE]: 'eventdate',
     [DIMENSION_TYPE_ENROLLMENT_DATE]: 'enrollmentdate',
     [DIMENSION_TYPE_INCIDENT_DATE]: 'incidentdate',


### PR DESCRIPTION
Related to [DHIS2-12482](https://jira.dhis2.org/browse/DHIS2-12482) and [TECH-960](https://jira.dhis2.org/browse/TECH-960)

---

### Key features

1. do not pass `createdBy` and `lastUpdatedBy` as dimensions in the analytics request
2. pass `createbydisplayname` and `lastupdatebydisplayname` when `createBy` and `lastUpdatedBy` dimensions are dragged into Columns

---

### Description

`createdBy` and `lastUpdatedBy` don't have a value selection, so they cannot be passed as dimensions, doing so results in an error (see Before screenshot).
However, they can be passed in `headers` so that analytics can return the data to display and they can be used for sorting the table.
(The error in the After screenshot is unrelated to this)

---

### Screenshots

Before:
<img width="927" alt="Screenshot 2022-02-18 at 10 12 27" src="https://user-images.githubusercontent.com/150978/154661592-6ada57f6-7276-4eab-9c3a-e5fc9aa66e72.png">

After:
<img width="923" alt="Screenshot 2022-02-18 at 10 15 24" src="https://user-images.githubusercontent.com/150978/154661719-c7f88fc0-17db-4b4d-ba10-91f1358e456b.png">

