### PR TITLE
fix: fix condition and items lookup by dimension

### DIFF
--- a/src/modules/current.js
+++ b/src/modules/current.js
@@ -48,12 +48,12 @@ export const getAxesFromUi = (ui) =>
 
                     return dimensionCreate(
                         dimensionId,
-                        ui.itemsByDimension[dimensionId],
+                        ui.itemsByDimension[id],
                         {
-                            filter: ui.conditions[dimensionId]?.condition,
-                            ...(ui.conditions[dimensionId]?.legendSet && {
+                            filter: ui.conditions[id]?.condition,
+                            ...(ui.conditions[id]?.legendSet && {
                                 legendSet: {
-                                    id: ui.conditions[dimensionId].legendSet,
+                                    id: ui.conditions[id].legendSet,
                                 },
                             }),
                             ...(programStageId && {


### PR DESCRIPTION
### Key features

1. fix conditions lookup
2. fix items lookup

---

### Description

The bug for 1. caused the condition to not be added as `filter` to the dimension object in `current`.
For 2. the lookup also needs to use the program stage id prefixed to the dimension id when available.

The key used in both objects (`itemsByDimension` and `conditions`) can contain the program stage id.
The lookup won't always work if only the dimension id is used.