### PR TITLE
feat: chip loading skeleton

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -178,7 +178,6 @@ const App = ({
     }
 
     const onResponseReceived = (response) => {
-        setVisualizationLoading(false)
         const itemsMetadata = Object.entries(response.metaData.items).reduce(
             (obj, [id, item]) => {
                 obj[id] = {
@@ -195,6 +194,7 @@ const App = ({
         )
 
         addMetadata(itemsMetadata)
+        setVisualizationLoading(false)
 
         if (!response.rows?.length) {
             setLoadError(emptyResponseError())

--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -83,6 +83,7 @@ const Chip = ({
                 [styles.active]: isDragging,
                 [styles.insertBefore]: insertPosition === BEFORE,
                 [styles.insertAfter]: insertPosition === AFTER,
+                [styles.showBlank]: !dimensionName,
             })}
         >
             <div className={styles.content}>
@@ -123,6 +124,7 @@ const Chip = ({
 
 Chip.propTypes = {
     dimensionId: PropTypes.string.isRequired,
+    showBlank: PropTypes.bool.isRequired,
     onClick: PropTypes.func.isRequired,
     activeIndex: PropTypes.number,
     contextMenu: PropTypes.object,

--- a/src/components/Layout/styles/Chip.module.css
+++ b/src/components/Layout/styles/Chip.module.css
@@ -21,6 +21,11 @@
     z-index: 100;
 }
 
+.showBlank .content {
+    visibility: hidden;
+    min-width: 100px;
+}
+
 /* the vertical line */
 .content::before {
     top: 6px;


### PR DESCRIPTION
Fixes visually broken chips while dimension name is unavailable

---

### Key features

1. Show a blank chip with a min-width while the metadata is still fetching
2. Set global loading state to `false` *after* the metadata has been set

---

### Description

We now show a blank chip while the metadata, containing the dimension names is being fetched. This is sort of a "skeleton loading UI".

Also, I implemented a change reg. the `isVisualizationLoading` state. In the end it wasn't even needed to implement this feature, but I decided to keep it anyway because I think it is more correct than what we had. In `App.js` in `onResponseReceived` we are now *first* setting the metadata, and *then* setting the visualization state. Components can use `isVisualizationLoading` as a trigger for doing stuff. It makes more sense that everything (including the metadata) has been processed before it switched to `false`.

---

### Known issues

- Strictly speaking, a skeleton loading UI should really meet this criterium: _Contents should replace skeleton exactly by position and size immediately after they are loaded_. This is not the case for us, but we thought it still looks better than an empty space.

---

### Screenshots

_supporting text_
