### PR TITLE
fix: restore-time-dimension-tests

### DIFF
--- a/src/modules/__tests__/timeDimensions.spec.js
+++ b/src/modules/__tests__/timeDimensions.spec.js
@@ -1,0 +1,281 @@
+import {
+    PROGRAM_TYPE_WITH_REGISTRATION,
+    PROGRAM_TYPE_WITHOUT_REGISTRATION,
+} from '../../components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js'
+import {
+    DIMENSION_TYPE_EVENT_DATE,
+    DIMENSION_TYPE_ENROLLMENT_DATE,
+    DIMENSION_TYPE_INCIDENT_DATE,
+    DIMENSION_TYPE_SCHEDULED_DATE,
+    DIMENSION_TYPE_LAST_UPDATED,
+} from '../dimensionTypes.js'
+import {
+    getTimeDimensionName,
+    getEnabledTimeDimensionIds,
+    getTimeDimensions,
+} from '../timeDimensions.js'
+import { OUTPUT_TYPE_ENROLLMENT, OUTPUT_TYPE_EVENT } from '../visualization.js'
+
+describe('ER > Dimensions > getTimeDimensionName', () => {
+    const timeDimensions = getTimeDimensions()
+    const eventDateDimension = timeDimensions[DIMENSION_TYPE_EVENT_DATE]
+    const enrollmentDateDimension =
+        timeDimensions[DIMENSION_TYPE_ENROLLMENT_DATE]
+    const incidentDateDimension = timeDimensions[DIMENSION_TYPE_INCIDENT_DATE]
+    /***** NOT in MVP / 2.38 release *****
+    const scheduledDateDimension = timeDimensions[DIMENSION_TYPE_SCHEDULED_DATE]
+    */
+    const lastUpdatedDimension = timeDimensions[DIMENSION_TYPE_LAST_UPDATED]
+
+    it('uses default names normally', () => {
+        const program = {
+            programType: 'WITHOUT_REGISTRATION',
+            programStages: [
+                {
+                    id: 'stage1Id',
+                },
+            ],
+        }
+        const stage = {
+            id: 'stage1Id',
+        }
+        Object.values(getTimeDimensions()).forEach((dimension) => {
+            expect(getTimeDimensionName(dimension, program, stage)).toEqual(
+                dimension.name
+            )
+        })
+    })
+    it('uses displayExecutionDateLabel from stage for event date', () => {
+        const program = {
+            programType: 'WITHOUT_REGISTRATION',
+            programStages: [
+                {
+                    id: 'stage1Id',
+                },
+            ],
+        }
+        const stage = {
+            displayExecutionDateLabel: 'le event date',
+            id: 'stage1Id',
+            name: 'The Only Stage',
+        }
+
+        expect(
+            getTimeDimensionName(eventDateDimension, program, stage)
+        ).toEqual(stage.displayExecutionDateLabel)
+        expect(
+            getTimeDimensionName(enrollmentDateDimension, program, stage)
+        ).toEqual(enrollmentDateDimension.name)
+        expect(
+            getTimeDimensionName(incidentDateDimension, program, stage)
+        ).toEqual(incidentDateDimension.name)
+        // expect(
+        //     getTimeDimensionName(scheduledDateDimension, program, stage)
+        // ).toEqual(scheduledDateDimension.name)
+        expect(
+            getTimeDimensionName(lastUpdatedDimension, program, stage)
+        ).toEqual(lastUpdatedDimension.name)
+    })
+    it('uses displayEnrollmentDateLabel from program for enrollment date', () => {
+        const program = {
+            programType: 'WITHOUT_REGISTRATION',
+            displayEnrollmentDateLabel: 'le enrollment date',
+            programStages: [
+                {
+                    id: 'stage1Id',
+                },
+            ],
+        }
+        const stage = {
+            id: 'stage1Id',
+            name: 'The Only Stage',
+        }
+
+        expect(
+            getTimeDimensionName(eventDateDimension, program, stage)
+        ).toEqual(eventDateDimension.name)
+        expect(
+            getTimeDimensionName(enrollmentDateDimension, program, stage)
+        ).toEqual(program.displayEnrollmentDateLabel)
+        expect(
+            getTimeDimensionName(incidentDateDimension, program, stage)
+        ).toEqual(incidentDateDimension.name)
+        // expect(
+        //     getTimeDimensionName(scheduledDateDimension, program, stage)
+        // ).toEqual(scheduledDateDimension.name)
+        expect(
+            getTimeDimensionName(lastUpdatedDimension, program, stage)
+        ).toEqual(lastUpdatedDimension.name)
+    })
+    it('uses displayDueDateLabel from stage for scheduled date', () => {
+        const program = {
+            programType: 'WITHOUT_REGISTRATION',
+            programStages: [
+                {
+                    id: 'stage1Id',
+                },
+            ],
+        }
+        const stage = {
+            id: 'stage1Id',
+            name: 'The Only Stage',
+            displayDueDateLabel: 'le due date',
+        }
+
+        expect(
+            getTimeDimensionName(eventDateDimension, program, stage)
+        ).toEqual(eventDateDimension.name)
+        expect(
+            getTimeDimensionName(enrollmentDateDimension, program, stage)
+        ).toEqual(enrollmentDateDimension.name)
+        expect(
+            getTimeDimensionName(incidentDateDimension, program, stage)
+        ).toEqual(incidentDateDimension.name)
+        // expect(
+        //     getTimeDimensionName(scheduledDateDimension, program, stage)
+        // ).toEqual(stage.displayDueDateLabel)
+        expect(
+            getTimeDimensionName(lastUpdatedDimension, program, stage)
+        ).toEqual(lastUpdatedDimension.name)
+    })
+    it('uses displayIncidentDateLabel from program for incident date', () => {
+        const program = {
+            programType: 'WITHOUT_REGISTRATION',
+            displayIncidentDateLabel: 'le incident date',
+            programStages: [
+                {
+                    id: 'stage1Id',
+                },
+            ],
+        }
+        const stage = {
+            id: 'stage1Id',
+            name: 'The Only Stage',
+        }
+
+        expect(
+            getTimeDimensionName(eventDateDimension, program, stage)
+        ).toEqual(eventDateDimension.name)
+        expect(
+            getTimeDimensionName(enrollmentDateDimension, program, stage)
+        ).toEqual(enrollmentDateDimension.name)
+        expect(
+            getTimeDimensionName(incidentDateDimension, program, stage)
+        ).toEqual(program.displayIncidentDateLabel)
+        // expect(
+        //     getTimeDimensionName(scheduledDateDimension, program, stage)
+        // ).toEqual(scheduledDateDimension.name)
+        expect(
+            getTimeDimensionName(lastUpdatedDimension, program, stage)
+        ).toEqual(lastUpdatedDimension.name)
+    })
+})
+
+describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
+    test.each([
+        // Nothing populated
+        {
+            inputType: undefined,
+            program: {
+                programType: undefined,
+                displayIncidentDate: undefined,
+            },
+            stage: {
+                id: '1',
+            },
+            expected: [],
+        },
+        // Max enabled - with registration / tracker
+        {
+            inputType: OUTPUT_TYPE_EVENT,
+            program: {
+                programType: PROGRAM_TYPE_WITH_REGISTRATION,
+                displayIncidentDate: true,
+            },
+            stage: {
+                id: '1',
+                hideDueDate: false,
+            },
+            expected: [
+                DIMENSION_TYPE_EVENT_DATE,
+                DIMENSION_TYPE_ENROLLMENT_DATE,
+                DIMENSION_TYPE_SCHEDULED_DATE,
+                DIMENSION_TYPE_INCIDENT_DATE,
+                DIMENSION_TYPE_LAST_UPDATED,
+            ],
+        },
+        // Hiding the due date
+        {
+            inputType: OUTPUT_TYPE_EVENT,
+            program: {
+                programType: PROGRAM_TYPE_WITH_REGISTRATION,
+                displayIncidentDate: true,
+            },
+            stage: {
+                id: '1',
+                hideDueDate: true,
+            },
+            expected: [
+                DIMENSION_TYPE_EVENT_DATE,
+                DIMENSION_TYPE_ENROLLMENT_DATE,
+                DIMENSION_TYPE_INCIDENT_DATE,
+                DIMENSION_TYPE_LAST_UPDATED,
+            ],
+        },
+        // Hiding the incident date
+        {
+            inputType: OUTPUT_TYPE_EVENT,
+            program: {
+                programType: PROGRAM_TYPE_WITH_REGISTRATION,
+                displayIncidentDate: false,
+            },
+            stage: {
+                id: '1',
+                hideDueDate: true,
+            },
+            expected: [
+                DIMENSION_TYPE_EVENT_DATE,
+                DIMENSION_TYPE_ENROLLMENT_DATE,
+                DIMENSION_TYPE_LAST_UPDATED,
+            ],
+        },
+        // input type enrollment
+        {
+            inputType: OUTPUT_TYPE_ENROLLMENT,
+            program: {
+                programType: PROGRAM_TYPE_WITH_REGISTRATION,
+                displayIncidentDate: true,
+            },
+            stage: {
+                id: '1',
+                hideDueDate: false,
+            },
+            expected: [
+                DIMENSION_TYPE_ENROLLMENT_DATE,
+                DIMENSION_TYPE_INCIDENT_DATE,
+                DIMENSION_TYPE_LAST_UPDATED,
+            ],
+        },
+        // Event program
+        {
+            inputType: OUTPUT_TYPE_EVENT,
+            program: {
+                programType: PROGRAM_TYPE_WITHOUT_REGISTRATION,
+                displayIncidentDate: true,
+            },
+            stage: {
+                id: '1',
+                hideDueDate: false,
+            },
+            expected: [DIMENSION_TYPE_EVENT_DATE, DIMENSION_TYPE_LAST_UPDATED],
+        },
+    ])(
+        'returns expected IDs for inputType $inputType, programType $program.programType with displayIncidentDate $program.displayIncidentDate and stage.hideDueDate $stage.hideDueDate',
+        ({ inputType, program, stage, expected }) => {
+            const actual = Array.from(
+                getEnabledTimeDimensionIds(inputType, program, stage)
+            )
+            expect(actual).toEqual(expected)
+        }
+    )
+})

--- a/src/modules/timeDimensions.js
+++ b/src/modules/timeDimensions.js
@@ -35,13 +35,15 @@ export const getTimeDimensions = () => ({
         nameParentProperty: NAME_PARENT_PROPERTY_PROGRAM,
         nameProperty: 'displayIncidentDateLabel',
     },
-    // [DIMENSION_TYPE_SCHEDULED_DATE]: {
-    //     id: DIMENSION_TYPE_SCHEDULED_DATE,
-    //     dimensionType: DIMENSION_TYPE_PERIOD,
-    //     name: i18n.t('Due/Scheduled date'),
-    //     nameParentProperty: NAME_PARENT_PROPERTY_STAGE,
-    //     nameProperty: 'displayDueDateLabel',
-    // },
+    /***** NOT in MVP / 2.38 release *****
+    [DIMENSION_TYPE_SCHEDULED_DATE]: {
+        id: DIMENSION_TYPE_SCHEDULED_DATE,
+        dimensionType: DIMENSION_TYPE_PERIOD,
+        name: i18n.t('Due/Scheduled date'),
+        nameParentProperty: NAME_PARENT_PROPERTY_STAGE,
+        nameProperty: 'displayDueDateLabel',
+    },
+    */
     [DIMENSION_TYPE_LAST_UPDATED]: {
         id: DIMENSION_TYPE_LAST_UPDATED,
         dimensionType: DIMENSION_TYPE_PERIOD,


### PR DESCRIPTION
### Description

I restored the tests that broke yesterday when I removed the `scheduledDate` dimension. Since this dimsnion is going to be added in the future, I decided to just comment everything out relating to that dimension, instead of deleting the code. So this PR doesn't contain any real changes, it's just a restoration of what we had in place already.

