### PR TITLE
feat: auto-select program stage and hide select if only one is present

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-23T07:43:38.398Z\n"
-"PO-Revision-Date: 2022-02-23T07:43:38.398Z\n"
+"POT-Creation-Date: 2022-02-23T11:37:56.069Z\n"
+"PO-Revision-Date: 2022-02-23T11:37:56.069Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -702,15 +702,6 @@ msgstr "Cancelled"
 
 msgid "Completed"
 msgstr "Completed"
-
-msgid "Overdue"
-msgstr "Overdue"
-
-msgid "Scheduled"
-msgstr "Scheduled"
-
-msgid "Skipped"
-msgstr "Skipped"
 
 msgid "Events are single registrations or incidents in a program"
 msgstr "Events are single registrations or incidents in a program"

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -78,10 +78,8 @@ const ProgramDimensionsPanel = ({ visible }) => {
         if (programId !== selectedProgramId) {
             const program = filteredPrograms?.find(({ id }) => id === programId)
             const stage =
-                program &&
-                // These have a single artificial stage
-                inputType === OUTPUT_TYPE_EVENT &&
-                program.programType === PROGRAM_TYPE_WITHOUT_REGISTRATION
+                // auto-select if a program only has a single stage
+                program?.programStages.length === 1
                     ? program.programStages[0]
                     : undefined
             dispatch(tSetUiProgram({ program, stage }))

--- a/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/StageSelect.js
@@ -19,7 +19,9 @@ const StageSelect = ({ optional, stages }) => {
             dispatch(tSetUiStage(stage))
         }
     }
-    const selected = selectedStageId || (optional && STAGE_ALL)
+    const includeShowAllOption = optional && stages.length > 1
+    const selected =
+        selectedStageId || (includeShowAllOption ? STAGE_ALL : undefined)
 
     return (
         <SingleSelect
@@ -28,7 +30,7 @@ const StageSelect = ({ optional, stages }) => {
             selected={selected}
             onChange={onChange}
         >
-            {optional && (
+            {includeShowAllOption && (
                 <SingleSelectOption label={i18n.t('All')} value={STAGE_ALL} />
             )}
             {stages.map(({ id, name }) => (


### PR DESCRIPTION
Implements KFMT issue, see thread (I meant to make this into a link, but Slack is down for me)

---

### Key features

1. Previously, we would only auto-select a program-stage in specific situaltions which only had a single artificial stage. Now we have generalised that a bit mnore, we will simply auto-select a stage if there is only 1 available.
2. Hide optional stage-select (below the type-select) in program-dimensions-filter component if only a single stage is found
3. Hide required stage-select (below the program select) in program-select component if only a single stage is found

---

### Screenshots
|  Input type | With single stage | With multiple stages |
| ------------- | ------------- |------------- |
| Event  | <img width="530" alt="Screenshot 2022-02-23 at 12 41 12" src="https://user-images.githubusercontent.com/353236/155313302-5269b719-8ce5-48f7-af35-4deca60aed14.png"> | <img width="524" alt="Screenshot 2022-02-23 at 12 49 44" src="https://user-images.githubusercontent.com/353236/155313994-baa83eff-2f40-487a-857e-76f204867ed0.png"> |
| Enrollment  | <img width="521" alt="Screenshot 2022-02-23 at 12 42 17" src="https://user-images.githubusercontent.com/353236/155313405-fe850a9d-cebf-426c-a09d-81200304afed.png"> | <img width="522" alt="Screenshot 2022-02-23 at 12 42 46" src="https://user-images.githubusercontent.com/353236/155313609-4ee1317c-0572-42e1-92ef-e556fd9fd6fc.png"> |





