### PR TITLE
fix: do not update current when validate layout fails

### DIFF
--- a/src/components/UpdateButton/UpdateVisualizationContainer.js
+++ b/src/components/UpdateButton/UpdateVisualizationContainer.js
@@ -23,15 +23,13 @@ const UpdateVisualizationContainer = ({
         try {
             validateLayout(getCurrentFromUi())
             clearLoadError()
+            onUpdate()
+            onLoadingStart()
         } catch (error) {
             setLoadError(error || genericClientError())
         }
 
         hideLayoutPanel()
-
-        onLoadingStart()
-
-        onUpdate()
 
         // const urlContainsCurrentAOKey =
         //     history.location.pathname === '/' + CURRENT_AO_KEY


### PR DESCRIPTION

### Key features

1. failure in layout validation should not trigger `current` update

---

### Description

Before regardless of wether the layout validation passed or failed, `current` was always updated from `ui`, causing a "corrupted" AO.
This was happening for example when the program is cleared in the ui, which does not generate a valid AO, but because `current` was updated anyway, it was also possible to try to save the "corrupted" AO, which resulted in an error from the backend.

The fix is to only update `current` if the layout validation passes.

### Screenshots

Compare the actions from "CLEAR_UI_PROGRAM":

Before:
<img width="1288" alt="Screenshot 2022-02-23 at 09 29 50" src="https://user-images.githubusercontent.com/150978/155296188-821c2c08-7dd8-43b4-b962-64670a7a5a21.png">

After:
<img width="1215" alt="Screenshot 2022-02-23 at 10 54 17" src="https://user-images.githubusercontent.com/150978/155296333-05b0a35a-b504-45aa-9d1b-50963b130596.png">

