### PR TITLE
fix: format analytics header with repetitions

### DIFF
--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -99,11 +99,19 @@ const getAdaptedVisualization = (visualization) => {
     const headers = [
         ...visualization[AXIS_ID_COLUMNS],
         ...visualization[AXIS_ID_ROWS],
-    ].map(({ dimension, programStage }) =>
-        programStage?.id
+    ].map(({ dimension, programStage, repetition }) => {
+        const headerId = programStage?.id
             ? `${programStage.id}.${dimension}`
             : headersMap[dimension] || dimension
-    )
+
+        if (repetition?.indexes?.length) {
+            return repetition.indexes.map((index) =>
+                headerId.replace(/\./, `[${index}].`)
+            )
+        } else {
+            return headerId
+        }
+    })
 
     return {
         adaptedVisualization: {


### PR DESCRIPTION

### Key features

1. pass ids with repetition indexes to analytics `headers`

---

### Description

When repeatable events are used, the dimension ids passed to analytics `headers` should match the ones passed in `dimension`, they should contain the repetition index.

### Screenshots

Before:
<img width="499" alt="Screenshot 2022-02-23 at 12 25 44" src="https://user-images.githubusercontent.com/150978/155310529-28633013-f3df-4f33-bd04-7f6762023cde.png">

<img width="574" alt="Screenshot 2022-02-23 at 12 25 26" src="https://user-images.githubusercontent.com/150978/155310493-823bbd40-e920-4189-9631-0ee67a96f51d.png">

After:
<img width="607" alt="Screenshot 2022-02-23 at 12 26 18" src="https://user-images.githubusercontent.com/150978/155310628-5d0d1463-1e93-472a-abc7-7051e9c0d793.png">

<img width="749" alt="Screenshot 2022-02-23 at 12 22 52" src="https://user-images.githubusercontent.com/150978/155310430-330cd327-2427-4f95-9bc1-dd757b978d8d.png">

