### PR TITLE
fix: remove grey area below the vis type selector

### DIFF
--- a/src/components/Toolbar/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
+++ b/src/components/Toolbar/VisualizationTypeSelector/styles/VisualizationTypeSelector.module.css
@@ -1,7 +1,6 @@
 .container {
     width: 260px;
     border-right: 1px solid #e0e2e4;
-    border-bottom: 1px solid #e0e2e4;
 }
 
 .arrowIcon {
@@ -10,6 +9,7 @@
 }
 
 .button {
+    height: 38px;
     padding: 7px var(--spacers-dp8);
     display: flex;
     align-items: center;


### PR DESCRIPTION

### Key features

1. fix vis type selector styles

---

### Screenshots

Before:
<img width="299" alt="Screenshot 2022-02-23 at 13 20 56" src="https://user-images.githubusercontent.com/150978/155318429-98611048-90fe-49b4-8594-ce2aae6b8e85.png">

After:
<img width="304" alt="Screenshot 2022-02-23 at 13 20 38" src="https://user-images.githubusercontent.com/150978/155318388-7ec91c5c-779a-41d6-80ec-99414c0744fc.png">

