### PR TITLE
fix: time dimension improvements

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,4 +1,7 @@
-import { DIMENSION_TYPES_PROGRAM } from '../modules/dimensionTypes.js'
+import {
+    DIMENSION_TYPES_PROGRAM,
+    DIMENSION_TYPES_TIME,
+} from '../modules/dimensionTypes.js'
 import {
     getDefaulTimeDimensionsMetadata,
     getDynamicTimeDimensionsMetadata,
@@ -68,13 +71,17 @@ export const acUpdateUiProgramStageId = (value, metadata) => ({
     metadata,
 })
 
-const tClearUiProgramDimensions = () => (dispatch, getState) => {
+const tClearUiProgramRelatedDimensions = () => (dispatch, getState) => {
     const { ui, metadata } = getState()
     const idsToRemove = ui.layout.columns
         .concat(ui.layout.filters)
-        .filter((dimensionId) =>
-            DIMENSION_TYPES_PROGRAM.has(metadata[dimensionId].dimensionType)
-        )
+        .filter((dimensionId) => {
+            const dimension = metadata[dimensionId]
+            return (
+                DIMENSION_TYPES_PROGRAM.has(dimension.dimensionType) ||
+                DIMENSION_TYPES_TIME.has(dimension.id)
+            )
+        })
     dispatch(acRemoveUiLayoutDimensions(idsToRemove))
     dispatch(acRemoveUiItems(idsToRemove))
 }
@@ -98,7 +105,7 @@ export const tClearUiProgramStageDimensions =
 
 export const tSetUiInput = (value) => (dispatch) => {
     dispatch(acClearUiProgram())
-    dispatch(tClearUiProgramDimensions())
+    dispatch(tClearUiProgramRelatedDimensions())
     dispatch(acSetUiInput(value, getDefaulTimeDimensionsMetadata()))
 }
 
@@ -106,7 +113,7 @@ export const tSetUiProgram =
     ({ program, stage }) =>
     (dispatch) => {
         dispatch(acClearUiProgram())
-        dispatch(tClearUiProgramDimensions())
+        dispatch(tClearUiProgramRelatedDimensions())
         program &&
             dispatch(
                 acUpdateUiProgramId(program.id, {
@@ -119,14 +126,14 @@ export const tSetUiProgram =
 
 export const tClearUiStage = () => (dispatch, getState) => {
     const state = getState()
-    const program = state.metadata[state.ui.program.id]
+    const program = sGetMetadataById(state, sGetUiProgramId(state))
 
     dispatch(acClearUiStageId(getDynamicTimeDimensionsMetadata(program)))
 }
 
 export const tSetUiStage = (stage) => (dispatch, getState) => {
     const state = getState()
-    const program = state.metadata[state.ui.program.id]
+    const program = sGetMetadataById(state, sGetUiProgramId(state))
     dispatch(
         acUpdateUiProgramStageId(
             stage.id,

--- a/src/components/Dialogs/PeriodDimension/PeriodDimension.js
+++ b/src/components/Dialogs/PeriodDimension/PeriodDimension.js
@@ -6,7 +6,7 @@ import i18n from '@dhis2/d2-i18n'
 import { SegmentedControl } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState, useMemo } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch, useSelector, useStore } from 'react-redux'
 import { tSetCurrentFromUi } from '../../../actions/current.js'
 import { acSetUiItems } from '../../../actions/ui.js'
 import {
@@ -62,8 +62,18 @@ const useLocalizedStartEndDateFormatter = () => {
     }
 }
 
+const useMetadataNameGetter = () => {
+    const store = useStore()
+
+    return (id) => {
+        const { metadata } = store.getState()
+        return metadata[id]?.name
+    }
+}
+
 export const PeriodDimension = ({ dimension, onClose }) => {
     const formatStartEndDate = useLocalizedStartEndDateFormatter()
+    const getNameFromMetadata = useMetadataNameGetter()
     const dispatch = useDispatch()
     const isInLayout = useIsInLayout(dimension?.id)
     const selectedIds =
@@ -73,11 +83,7 @@ export const PeriodDimension = ({ dimension, onClose }) => {
     const [presets, setPresets] = useState(() =>
         selectedIds
             .filter((id) => !isStartEndDate(id))
-            /*
-             * TODO: it should be possible to fetch the names from the metadata
-             * store once the backend starts returning period dimension metadata
-             */
-            .map((id) => ({ id, name: id }))
+            .map((id) => ({ id, name: getNameFromMetadata(id) }))
     )
 
     const [startEndDate, setStartEndDate] = useState(

--- a/src/modules/__tests__/timeDimensions.spec.js
+++ b/src/modules/__tests__/timeDimensions.spec.js
@@ -251,6 +251,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 hideDueDate: false,
             },
             expected: [
+                DIMENSION_TYPE_EVENT_DATE,
                 DIMENSION_TYPE_ENROLLMENT_DATE,
                 DIMENSION_TYPE_INCIDENT_DATE,
                 DIMENSION_TYPE_LAST_UPDATED,

--- a/src/modules/__tests__/timeDimensions.spec.js
+++ b/src/modules/__tests__/timeDimensions.spec.js
@@ -251,7 +251,6 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 hideDueDate: false,
             },
             expected: [
-                DIMENSION_TYPE_EVENT_DATE,
                 DIMENSION_TYPE_ENROLLMENT_DATE,
                 DIMENSION_TYPE_INCIDENT_DATE,
                 DIMENSION_TYPE_LAST_UPDATED,

--- a/src/modules/metadata.js
+++ b/src/modules/metadata.js
@@ -27,8 +27,6 @@ const getFixedDimensions = () => ({
 })
 
 export const getDefaultMetadata = () => ({
-    // default selected period
-    THIS_MONTH: { name: i18n.t('This month') },
     ...getMainDimensions(),
     ...getDefaulTimeDimensionsMetadata(),
     ...getFixedDimensions(),

--- a/src/modules/timeDimensions.js
+++ b/src/modules/timeDimensions.js
@@ -8,7 +8,7 @@ import {
     DIMENSION_TYPE_LAST_UPDATED,
 } from './dimensionTypes.js'
 import { PROGRAM_TYPE_WITH_REGISTRATION } from './programTypes.js'
-import { OUTPUT_TYPE_EVENT } from './visualization.js'
+import { OUTPUT_TYPE_EVENT, OUTPUT_TYPE_ENROLLMENT } from './visualization.js'
 
 const NAME_PARENT_PROPERTY_PROGRAM = 'program'
 const NAME_PARENT_PROPERTY_STAGE = 'stage'
@@ -67,10 +67,15 @@ export const getEnabledTimeDimensionIds = (inputType, program, stage) => {
     const enabledDimensionIds = new Set()
     if (inputType) {
         const isEvent = inputType === OUTPUT_TYPE_EVENT
+        const isEnrollment = inputType === OUTPUT_TYPE_ENROLLMENT
         const withRegistration =
             program?.programType === PROGRAM_TYPE_WITH_REGISTRATION
 
         if (isEvent) {
+            enabledDimensionIds.add(DIMENSION_TYPE_EVENT_DATE)
+        }
+
+        if (isEnrollment) {
             enabledDimensionIds.add(DIMENSION_TYPE_EVENT_DATE)
         }
 
@@ -85,7 +90,7 @@ export const getEnabledTimeDimensionIds = (inputType, program, stage) => {
                 enabledDimensionIds.add(DIMENSION_TYPE_INCIDENT_DATE)
         }
 
-        if (isEvent || withRegistration) {
+        if (isEvent || isEnrollment || withRegistration) {
             enabledDimensionIds.add(DIMENSION_TYPE_LAST_UPDATED)
         }
     }

--- a/src/modules/timeDimensions.js
+++ b/src/modules/timeDimensions.js
@@ -76,7 +76,7 @@ export const getEnabledTimeDimensionIds = (inputType, program, stage) => {
         }
 
         if (isEnrollment) {
-            enabledDimensionIds.add(DIMENSION_TYPE_EVENT_DATE)
+            enabledDimensionIds.add(DIMENSION_TYPE_ENROLLMENT_DATE)
         }
 
         if (withRegistration) {

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -77,12 +77,11 @@ export const DEFAULT_UI = {
     program: {},
     layout: {
         // TODO: Populate the layout with the correct default dimensions, these are just temporary for testing
-        columns: [DIMENSION_ID_ORGUNIT, DIMENSION_TYPE_EVENT_DATE],
+        columns: [DIMENSION_ID_ORGUNIT],
         filters: [],
     },
     itemsByDimension: {
         [DIMENSION_ID_ORGUNIT]: [],
-        [DIMENSION_TYPE_EVENT_DATE]: ['THIS_MONTH'],
         [DIMENSION_TYPE_EVENT_STATUS]: [],
         [DIMENSION_TYPE_PROGRAM_STATUS]: [],
     },


### PR DESCRIPTION
Implements:
- [TECH-979](https://jira.dhis2.org/browse/TECH-979)
- A number of KFMT issues related to period/time dimensions

---

### Key features

1. Use names from metadata to set initially selected period items ([TECH-979](https://jira.dhis2.org/browse/TECH-979))
2. Tweak default time dimension selection, see [Slack thread](https://dhis2.slack.com/archives/G3TL0J145/p1645628057636699)
3. Clear time dimensions from layout when switching Input / program, see [Slack thread](https://dhis2.slack.com/archives/D9N90FGCQ/p1645613457823179)

---

### Description

Below some details about the key features:
1. Since the backend is now including the names of the period dimension items in the `metadata.items` in the analytics response, it is now possible to start using these names for the intitially selected period dimensions.
2. The changes to the default time selection caused one test to break because in one of the tests it was enabling one extra time dimension. I have adjusted the expected values in the test, because I believe the following is correct, could you please confirm @janhenrikoverland?
    ```js
    {
        // inputType, program and stage args for getEnabledTimeDimensionIds
        inputType: OUTPUT_TYPE_ENROLLMENT,
        program: {
            programType: PROGRAM_TYPE_WITH_REGISTRATION,
            displayIncidentDate: true,
        },
        stage: {
            id: '1',
            hideDueDate: false,
        },
        // expected enabled dimensions
        expected: [
            DIMENSION_TYPE_EVENT_DATE, // NEW ADDITION IN THIS PR
            DIMENSION_TYPE_ENROLLMENT_DATE,
            DIMENSION_TYPE_INCIDENT_DATE,
            DIMENSION_TYPE_LAST_UPDATED,
        ],
    },
    ```
3. At first we were simply clearing all the time dimensions when the input or program changed or was cleared. However, I discussed with @janhenrikoverland that it would also be possible to keep some of the time dimensions in place. This seemed like a good idea so that's what I've implemented now: the time dimensions that are going to get disabled are getting removed and the other ones are kept in place. We couldn't think of any situations where this would be problematic, but could have overlooked something, so please pay extra attention to that part when reviewing.

---

### Screenshots

*Names from metadata*
<img width="819" alt="Screenshot 2022-02-24 at 09 56 27" src="https://user-images.githubusercontent.com/353236/155491586-ecfcb69d-9e66-47f9-bb04-4c36ebebab46.png">
<img width="246" alt="Screenshot 2022-02-24 at 09 56 15" src="https://user-images.githubusercontent.com/353236/155491592-bfb9253b-4cbe-47f6-a9a6-93f1b38250c4.png">

*Default selection*
<img width="1282" alt="Screenshot 2022-02-24 at 09 54 53" src="https://user-images.githubusercontent.com/353236/155491383-b0e6c1a3-c42c-41a1-a0d1-06ff1abf75fb.png">
