### PR TITLE
fix: parse repetition when loading a visualization

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-23T11:37:56.069Z\n"
-"PO-Revision-Date: 2022-02-23T11:37:56.069Z\n"
+"POT-Creation-Date: 2022-02-24T07:52:19.703Z\n"
+"PO-Revision-Date: 2022-02-24T07:52:19.703Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -451,6 +451,12 @@ msgstr "Click a dimension to add or remove conditions."
 
 msgid "Your most viewed event reports"
 msgstr "Your most viewed event reports"
+
+msgid "most recent"
+msgstr "most recent"
+
+msgid "oldest"
+msgstr "oldest"
 
 msgid "Cases per page"
 msgstr "Cases per page"

--- a/src/modules/repetition.js
+++ b/src/modules/repetition.js
@@ -1,0 +1,16 @@
+import { layoutGetAllDimensions } from '@dhis2/analytics'
+import { parseCurrentRepetition } from './ui.js'
+
+export const getRepetitionFromVisualisation = (vis) => {
+    const repetitionByDimension = {}
+    layoutGetAllDimensions(vis)
+        .filter((d) => d.repetition)
+        .forEach((d) => {
+            repetitionByDimension[
+                d.programStage?.id
+                    ? `${d.programStage.id}.${d.dimension}`
+                    : d.dimension
+            ] = parseCurrentRepetition(d.repetition.indexes)
+        })
+    return repetitionByDimension
+}

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -11,6 +11,7 @@ import { getAdaptedUiLayoutByType, getInverseLayout } from './layout.js'
 import { getOptionsFromVisualization } from './options.js'
 import { removeLastPathSegment } from './orgUnit.js'
 import { getProgramFromVisualisation } from './program.js'
+import { getRepetitionFromVisualisation } from './repetition.js'
 
 const lineListUiAdapter = (ui) => ({
     ...ui,
@@ -39,6 +40,7 @@ export const getUiFromVisualization = (vis, currentState = {}) => ({
         vis.parentGraphMap ||
         getParentGraphMapFromVisualization(vis) ||
         currentState.parentGraphMap,
+    repetitionByDimension: getRepetitionFromVisualisation(vis),
 })
 
 export const getParentGraphMapFromVisualization = (vis) => {


### PR DESCRIPTION
### Description

Parses the `repetition` field for each dimension to `repetitionByDimension` when loading a visualiation.

---

### Known issues

- [ ] The name for data element dimensions is missing from `metadata` on load