### PR TITLE
fix: include valueType when setting metadata while dragging dimension items

### DIFF
--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -256,6 +256,7 @@ const OuterDndContext = ({ children }) => {
                     id,
                     name: active.data.current.name,
                     dimensionType: active.data.current.dimensionType,
+                    valueType: active.data.current.valueType,
                 },
             })
         )

--- a/src/components/MainSidebar/DimensionItem/DimensionItem.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItem.js
@@ -51,6 +51,7 @@ export const DimensionItem = ({
         data: {
             name,
             dimensionType,
+            valueType,
         },
     })
 


### PR DESCRIPTION
### Key features

1. include valueType when setting metadata while dragging dimension items

---

### Screenshots


https://user-images.githubusercontent.com/6113918/155508846-43e0368d-d25a-44f2-9594-366b51a7821f.mov


