### PR TITLE
fix: hide your dimensions button when no dimensions are available

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-23T11:37:56.069Z\n"
-"PO-Revision-Date: 2022-02-23T11:37:56.069Z\n"
+"POT-Creation-Date: 2022-02-24T10:56:43.943Z\n"
+"PO-Revision-Date: 2022-02-24T10:56:43.943Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -353,9 +353,6 @@ msgstr "Input: {{type}}"
 msgid "Program dimensions"
 msgstr "Program dimensions"
 
-msgid "Your dimensions"
-msgstr "Your dimensions"
-
 msgid "Search in program"
 msgstr "Search in program"
 
@@ -405,6 +402,9 @@ msgstr "Stage"
 msgid "Time dimensions"
 msgstr "Time dimensions"
 
+msgid "Your dimensions"
+msgstr "Your dimensions"
+
 msgid "Search your dimensions"
 msgstr "Search your dimensions"
 
@@ -451,6 +451,12 @@ msgstr "Click a dimension to add or remove conditions."
 
 msgid "Your most viewed event reports"
 msgstr "Your most viewed event reports"
+
+msgid "most recent"
+msgstr "most recent"
+
+msgid "oldest"
+msgstr "oldest"
 
 msgid "Cases per page"
 msgstr "Cases per page"

--- a/src/components/MainSidebar/MainSidebar.js
+++ b/src/components/MainSidebar/MainSidebar.js
@@ -18,6 +18,7 @@ import {
     useSelectedDimensions,
 } from './SelectedDimensionsContext.js'
 import { TimeDimensions } from './TimeDimensions.js'
+import { YourDimensions } from './YourDimensions.js'
 import { YourDimensionsPanel } from './YourDimensionsPanel/index.js'
 
 const TAB_INPUT = 'INPUT'
@@ -62,12 +63,10 @@ const MainSidebar = () => {
                     selected={open && selectedTabId === TAB_PROGRAM}
                     count={counts.program}
                 />
-                <MenuItem
-                    icon={<IconFolder16 />}
-                    label={i18n.t('Your dimensions')}
-                    onClick={() => onClick(TAB_YOUR)}
+                <YourDimensions
                     selected={open && selectedTabId === TAB_YOUR}
                     count={counts.your}
+                    onClick={() => onClick(TAB_YOUR)}
                 />
                 <MainDimensions />
                 <TimeDimensions />

--- a/src/components/MainSidebar/MainSidebar.js
+++ b/src/components/MainSidebar/MainSidebar.js
@@ -18,7 +18,7 @@ import {
     useSelectedDimensions,
 } from './SelectedDimensionsContext.js'
 import { TimeDimensions } from './TimeDimensions.js'
-import { YourDimensions } from './YourDimensions.js'
+import { YourDimensionsMenuItem } from './YourDimensionsMenuItem.js'
 import { YourDimensionsPanel } from './YourDimensionsPanel/index.js'
 
 const TAB_INPUT = 'INPUT'
@@ -63,7 +63,7 @@ const MainSidebar = () => {
                     selected={open && selectedTabId === TAB_PROGRAM}
                     count={counts.program}
                 />
-                <YourDimensions
+                <YourDimensionsMenuItem
                     selected={open && selectedTabId === TAB_YOUR}
                     count={counts.your}
                     onClick={() => onClick(TAB_YOUR)}

--- a/src/components/MainSidebar/YourDimensions.js
+++ b/src/components/MainSidebar/YourDimensions.js
@@ -5,18 +5,18 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { MenuItem } from './MenuItem/index.js'
 import {
-    yourDimensionsResource,
-    yourDimensionsFilter,
+    YOUR_DIMENSIONS_RESOURCE,
+    YOUR_DIMENSIONS_FILTER,
 } from './YourDimensionsPanel/useYourDimensions.js'
 
 const query = {
     dimensions: {
-        resource: yourDimensionsResource,
+        resource: YOUR_DIMENSIONS_RESOURCE,
         params: {
             page: 1,
             pageSize: 1,
             fields: 'id',
-            filter: yourDimensionsFilter,
+            filter: YOUR_DIMENSIONS_FILTER,
         },
     },
 }

--- a/src/components/MainSidebar/YourDimensions.js
+++ b/src/components/MainSidebar/YourDimensions.js
@@ -1,0 +1,42 @@
+import { useDataQuery } from '@dhis2/app-runtime'
+import i18n from '@dhis2/d2-i18n'
+import { IconFolder16 } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { MenuItem } from './MenuItem/index.js'
+import {
+    yourDimensionsResource,
+    yourDimensionsFilter,
+} from './YourDimensionsPanel/useYourDimensions.js'
+
+const query = {
+    dimensions: {
+        resource: yourDimensionsResource,
+        params: {
+            page: 1,
+            pageSize: 1,
+            fields: 'id',
+            filter: yourDimensionsFilter,
+        },
+    },
+}
+
+export const YourDimensions = ({ selected, count, onClick }) => {
+    const { data } = useDataQuery(query)
+
+    return data?.dimensions.dimensions?.length ? (
+        <MenuItem
+            icon={<IconFolder16 />}
+            label={i18n.t('Your dimensions')}
+            onClick={onClick}
+            selected={selected}
+            count={count}
+        />
+    ) : null
+}
+
+YourDimensions.propTypes = {
+    count: PropTypes.number.isRequired,
+    selected: PropTypes.bool.isRequired,
+    onClick: PropTypes.func.isRequired,
+}

--- a/src/components/MainSidebar/YourDimensionsMenuItem.js
+++ b/src/components/MainSidebar/YourDimensionsMenuItem.js
@@ -21,7 +21,7 @@ const query = {
     },
 }
 
-export const YourDimensions = ({ selected, count, onClick }) => {
+export const YourDimensionsMenuItem = ({ selected, count, onClick }) => {
     const { data } = useDataQuery(query)
 
     return data?.dimensions.dimensions?.length ? (
@@ -35,7 +35,7 @@ export const YourDimensions = ({ selected, count, onClick }) => {
     ) : null
 }
 
-YourDimensions.propTypes = {
+YourDimensionsMenuItem.propTypes = {
     count: PropTypes.number.isRequired,
     selected: PropTypes.bool.isRequired,
     onClick: PropTypes.func.isRequired,

--- a/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
+++ b/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
@@ -2,22 +2,25 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import { useEffect, useState } from 'react'
 import { DIMENSION_LIST_FIELDS } from '../DimensionsList/index.js'
 
+const yourDimensionsResource = 'dimensions'
+// Fixed filter on org units for 2.38 ?
+const yourDimensionsFilter = 'dimensionType:eq:ORGANISATION_UNIT_GROUP_SET'
+
 const query = {
     dimensions: {
-        resource: 'dimensions',
+        resource: yourDimensionsResource,
         params: ({ page, searchTerm }) => {
-            // Fixed filer on org units for 2.38 ?
-            const filter = ['dimensionType:eq:ORGANISATION_UNIT_GROUP_SET']
+            const filters = [yourDimensionsFilter]
 
             if (searchTerm) {
-                filter.push(`name:ilike:${searchTerm}`)
+                filters.push(`name:ilike:${searchTerm}`)
             }
 
             return {
                 pageSize: 50,
                 page,
                 fields: DIMENSION_LIST_FIELDS,
-                filter,
+                filter: filters,
             }
         },
     },
@@ -83,4 +86,4 @@ const useYourDimensions = ({ visible, searchTerm }) => {
     }
 }
 
-export { useYourDimensions }
+export { useYourDimensions, yourDimensionsFilter, yourDimensionsResource }

--- a/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
+++ b/src/components/MainSidebar/YourDimensionsPanel/useYourDimensions.js
@@ -2,15 +2,15 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import { useEffect, useState } from 'react'
 import { DIMENSION_LIST_FIELDS } from '../DimensionsList/index.js'
 
-const yourDimensionsResource = 'dimensions'
+const YOUR_DIMENSIONS_RESOURCE = 'dimensions'
 // Fixed filter on org units for 2.38 ?
-const yourDimensionsFilter = 'dimensionType:eq:ORGANISATION_UNIT_GROUP_SET'
+const YOUR_DIMENSIONS_FILTER = 'dimensionType:eq:ORGANISATION_UNIT_GROUP_SET'
 
 const query = {
     dimensions: {
-        resource: yourDimensionsResource,
+        resource: YOUR_DIMENSIONS_RESOURCE,
         params: ({ page, searchTerm }) => {
-            const filters = [yourDimensionsFilter]
+            const filters = [YOUR_DIMENSIONS_FILTER]
 
             if (searchTerm) {
                 filters.push(`name:ilike:${searchTerm}`)
@@ -86,4 +86,4 @@ const useYourDimensions = ({ visible, searchTerm }) => {
     }
 }
 
-export { useYourDimensions, yourDimensionsFilter, yourDimensionsResource }
+export { useYourDimensions, YOUR_DIMENSIONS_FILTER, YOUR_DIMENSIONS_RESOURCE }


### PR DESCRIPTION
### Key features

1. hide your dimensions button if no your dimensions are available

---

### Description

Moved the menu item for Your dimensions into a separate component which queries the `dimensions` endpoint to check if any dimension is available.
If not, hide the button as clicking it would result in an empty list in the panel.