### PR TITLE
feat: show dashed style on program dimension badge if no program is selected

### DIFF
--- a/src/components/MainSidebar/MainSidebar.js
+++ b/src/components/MainSidebar/MainSidebar.js
@@ -7,7 +7,11 @@ import {
     acSetUiAccessoryPanelOpen,
     acSetUiDetailsPanelOpen,
 } from '../../actions/ui.js'
-import { sGetUiInputType, sGetUiShowAccessoryPanel } from '../../reducers/ui.js'
+import {
+    sGetUiInputType,
+    sGetUiShowAccessoryPanel,
+    sGetUiProgramId,
+} from '../../reducers/ui.js'
 import { InputPanel, getLabelForInputType } from './InputPanel/index.js'
 import { MainDimensions } from './MainDimensions.js'
 import styles from './MainSidebar.module.css'
@@ -28,6 +32,7 @@ const MainSidebar = () => {
     const dispatch = useDispatch()
     const open = useSelector(sGetUiShowAccessoryPanel)
     const selectedInputType = useSelector(sGetUiInputType)
+    const selectedProgramId = useSelector(sGetUiProgramId)
     const [selectedTabId, setSelectedTabId] = useState(null)
     const setOpen = (newOpen) => dispatch(acSetUiAccessoryPanelOpen(newOpen))
     const closeDetailsPanel = () => dispatch(acSetUiDetailsPanelOpen(false))
@@ -61,6 +66,7 @@ const MainSidebar = () => {
                     onClick={() => onClick(TAB_PROGRAM)}
                     selected={open && selectedTabId === TAB_PROGRAM}
                     count={counts.program}
+                    isCountDisabled={!selectedProgramId}
                 />
                 <MenuItem
                     icon={<IconFolder16 />}

--- a/src/components/MainSidebar/MenuItem/MenuItem.js
+++ b/src/components/MainSidebar/MenuItem/MenuItem.js
@@ -4,7 +4,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './MenuItem.module.css'
 
-const MenuItem = ({ icon, label, count, onClick, selected }) => (
+const MenuItem = ({
+    icon,
+    label,
+    count,
+    onClick,
+    isCountDisabled,
+    selected,
+}) => (
     <div
         className={cx(styles.container, { [styles.selected]: selected })}
         onClick={onClick}
@@ -12,8 +19,14 @@ const MenuItem = ({ icon, label, count, onClick, selected }) => (
     >
         <div className={styles.icon}>{icon}</div>
         <div className={styles.label}>{label}</div>
-        {typeof count === 'number' && count > 0 && (
-            <div className={styles.count}>{count}</div>
+        {typeof count === 'number' && (
+            <div
+                className={cx(styles.count, {
+                    [styles.dashed]: isCountDisabled,
+                })}
+            >
+                {count}
+            </div>
         )}
         <IconChevronRight16 />
     </div>
@@ -24,6 +37,7 @@ MenuItem.propTypes = {
     label: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired,
     count: PropTypes.number,
+    isCountDisabled: PropTypes.bool,
     selected: PropTypes.bool,
 }
 

--- a/src/components/MainSidebar/MenuItem/MenuItem.module.css
+++ b/src/components/MainSidebar/MenuItem/MenuItem.module.css
@@ -55,18 +55,13 @@
     justify-content: center;
     padding: 2px 6px;
     color: var(--colors-grey700);
-    background-color: var(--colors-grey300);
+    background-color: rgba(160, 173, 186, 0.2);
     font-size: 12px;
+    line-height: 12px;
     border-radius: 4px;
     border: 1px dashed transparent;
 }
-/* The count badge needs to be darker when hovering 
-   a selected menu item, otherwise it's nearly the same
-   as the container's background */
-.container.selected:hover .count:not(.dashed) {
-    background-color: var(--colors-grey400);
-}
 .count.dashed {
-    background-color: var(--colors-white);
-    border-color: var(--colors-grey500);
+    border-color: rgba(74, 87, 104, 0.4);
+    background-color: transparent;
 }

--- a/src/components/MainSidebar/MenuItem/MenuItem.module.css
+++ b/src/components/MainSidebar/MenuItem/MenuItem.module.css
@@ -55,7 +55,18 @@
     justify-content: center;
     padding: 2px 6px;
     color: var(--colors-grey700);
-    background-color: var(--colors-grey200);
+    background-color: var(--colors-grey300);
     font-size: 12px;
     border-radius: 4px;
+    border: 1px dashed transparent;
+}
+/* The count badge needs to be darker when hovering 
+   a selected menu item, otherwise it's nearly the same
+   as the container's background */
+.container.selected:hover .count:not(.dashed) {
+    background-color: var(--colors-grey400);
+}
+.count.dashed {
+    background-color: var(--colors-white);
+    border-color: var(--colors-grey500);
 }


### PR DESCRIPTION
Implements KMFT point from [this Slack thread](https://dhis2.slack.com/archives/G3TL0J145/p1645628699820989)

---

### Key features

1. If no program is selected the program dimension menu item count badge now gets a custom dashed style
2. The badge will still display if count equals `0` (before it would not render)
3. I noticed that when a menu item is selected and being hovered, the color of it is very close to the color of the badge, so I added an additional style to remedy this.

---

### Remark

Reg point 3 above, I guess mainly for @cooper-joe:  I think it'd make more sense to go with teal for these badges instead of grey. Firstly because teal is the color we have associated with "selection" in our design system. Secondly because that would fix the issue with the hover-styles and badge styles colliding in a more consistent way.

### Screenshots
*No program selected*
<img width="261" alt="Screenshot 2022-02-24 at 15 39 30" src="https://user-images.githubusercontent.com/353236/155545438-4d1edce9-d69e-4525-9d01-c9d533f19c46.png">

*Program selected*
<img width="263" alt="Screenshot 2022-02-24 at 15 40 14" src="https://user-images.githubusercontent.com/353236/155545513-f7c0c296-b3b5-4605-b42a-47348e3abc3f.png">

Note: Both screenshots are showing the hover state of the menu-item