### PR TITLE
fix: use a left border on right sidebar when open

### DIFF
--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -61,9 +61,11 @@
     overflow-x: hidden;
     transform: scaleX(1);
     transition: width 200ms ease-out;
+    border-left: 1px solid var(--colors-grey400);
 }
 .mainRight.hidden {
     width: 0;
+    border: none;
 }
 /* Main canvas */
 


### PR DESCRIPTION
### Key features

1. show a border on the left of the right sidebar when open

---

### Description

The border between the right sidebar and the main content was missing when the sidebar is open.

---

### Screenshots

Before:
<img width="442" alt="Screenshot 2022-02-24 at 14 27 55" src="https://user-images.githubusercontent.com/150978/155532977-ce9822cf-5c03-48e1-adcb-2f680fdbcd31.png">

After:
<img width="488" alt="Screenshot 2022-02-24 at 14 24 10" src="https://user-images.githubusercontent.com/150978/155532840-bf9febd6-31c4-49fe-b100-befb1b06635d.png">

