### PR TITLE
feat: apply font size and padding based on settings

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -45,6 +45,17 @@ const getFontSizeClass = (fontSize) => {
     }
 }
 
+const getSizeClass = (displayDensity) => {
+    switch (displayDensity) {
+        case DISPLAY_DENSITY_COMFORTABLE:
+            return styles.sizeComfortable
+        case DISPLAY_DENSITY_COMPACT:
+            return styles.sizeCompact
+        default:
+            return styles.sizeNormal
+    }
+}
+
 export const Visualization = ({
     visualization,
     onResponseReceived,
@@ -105,8 +116,7 @@ export const Visualization = ({
         return null
     }
 
-    const large = visualization.displayDensity === DISPLAY_DENSITY_COMFORTABLE
-    const small = visualization.displayDensity === DISPLAY_DENSITY_COMPACT
+    const sizeClass = getSizeClass(visualization.displayDensity)
     const fontSizeClass = getFontSizeClass(visualization.fontSize)
     const colSpan = String(Math.max(data.headers.length, 1))
 
@@ -165,6 +175,7 @@ export const Visualization = ({
                     scrollHeight="100%"
                     width="auto"
                     scrollWidth={`${availableOuterWidth}px`}
+                    className={styles.dataTable}
                 >
                     <DataTableHead>
                         <DataTableRow>
@@ -189,9 +200,11 @@ export const Visualization = ({
                                                 ? sortDirection
                                                 : 'default'
                                         }
-                                        large={large}
-                                        small={small}
-                                        className={fontSizeClass}
+                                        className={cx(
+                                            styles.headerCell,
+                                            fontSizeClass,
+                                            sizeClass
+                                        )}
                                     >
                                         {formatCellHeader(header)}
                                     </DataTableColumnHeader>
@@ -200,9 +213,11 @@ export const Visualization = ({
                                         fixed
                                         top="0"
                                         key={`undefined_${index}`} // FIXME this is due to pe not being present in headers, needs special handling
-                                        large={large}
-                                        small={small}
-                                        className={fontSizeClass}
+                                        className={cx(
+                                            styles.headerCell,
+                                            fontSizeClass,
+                                            sizeClass
+                                        )}
                                     />
                                 )
                             )}
@@ -215,9 +230,11 @@ export const Visualization = ({
                                 {row.map((value, index) => (
                                     <DataTableCell
                                         key={index}
-                                        large={large}
-                                        small={small}
-                                        className={fontSizeClass}
+                                        className={cx(
+                                            styles.cell,
+                                            fontSizeClass,
+                                            sizeClass
+                                        )}
                                     >
                                         {formatCellValue(
                                             value,
@@ -236,7 +253,10 @@ export const Visualization = ({
                                 className={styles.footerCell}
                             >
                                 <div
-                                    className={styles.stickyNavigation}
+                                    className={cx(
+                                        styles.stickyNavigation,
+                                        sizeClass
+                                    )}
                                     style={{
                                         maxWidth: availableInnerWidth,
                                     }}

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -59,19 +59,63 @@
 .stickyNavigation {
     position: sticky;
     left: 0;
+}
+
+/* Table header cells in various sizes */
+.dataTable .headerCell.fontSizeLarge {
+    font-size: 15px;
+    line-height: 16px;
+}
+.dataTable .headerCell.fontSizeNormal {
+    font-size: 12px;
+    line-height: 13px;
+}
+.dataTable .headerCell.fontSizeSmall {
+    font-size: 10px;
+    line-height: 11px;
+}
+.dataTable .headerCell.sizeComfortable {
+    padding: 16px 12px;
+}
+.dataTable .headerCell.sizeNormal {
+    padding: 8px 8px;
+}
+.dataTable .headerCell.sizeCompact {
+    padding: 4px 8px;
+}
+
+/* Table body cells in various sizes */
+.dataTable .cell.fontSizeLarge {
+    font-size: 15px;
+    line-height: 16px;
+}
+.dataTable .cell.fontSizeNormal {
+    font-size: 12px;
+    line-height: 13px;
+}
+.dataTable .cell.fontSizeSmall {
+    font-size: 10px;
+    line-height: 11px;
+}
+.dataTable .cell.sizeComfortable {
+    padding: 16px 12px;
+}
+.dataTable .cell.sizeNormal {
+    padding: 8px 8px;
+}
+.dataTable .cell.sizeCompact {
+    padding: 4px 8px;
+}
+
+/* Sizes for the table footer */
+.dataTable .stickyNavigation.sizeComfortable {
     padding: 14px 12px;
 }
-
-.fontSizeLarge {
-    font-size: 13px !important;
+.dataTable .stickyNavigation.sizeNormal {
+    padding: 10px 12px;
 }
-
-.fontSizeNormal {
-    font-size: 11px !important;
-}
-
-.fontSizeSmall {
-    font-size: 10px !important;
+.dataTable .stickyNavigation.sizeCompact {
+    padding: 6px 12px;
 }
 .error {
     flex: 1;

--- a/src/components/Visualization/styles/Visualization.module.css
+++ b/src/components/Visualization/styles/Visualization.module.css
@@ -75,13 +75,13 @@
     line-height: 11px;
 }
 .dataTable .headerCell.sizeComfortable {
-    padding: 16px 12px;
+    padding: 12px 12px;
 }
 .dataTable .headerCell.sizeNormal {
-    padding: 8px 8px;
+    padding: 4px 8px;
 }
 .dataTable .headerCell.sizeCompact {
-    padding: 4px 8px;
+    padding: 0px 8px;
 }
 
 /* Table body cells in various sizes */


### PR DESCRIPTION
Implements Visualization sizes from options 

---

### Key features

1. Data table cells are padded according to the "Display density" option
2. Data table cells get a font size from the "Font size" option 

---

### Description

This PR comes with some notes:
- The data-table component from @dhis2/ui did already come with a `large` prop, but no `small` prop was available yet, and this is not planned either. Joe advised to apply custom styling in the app, which I did.
- Changing the content of the pagination is a bit tricky. So it was discussed that for the MVP we just decrease the padding a bit when the dispaly density changes. 

---

### TODO

-   [ ] The data table in `@dhis2/ui` uses a slightly different padding and font-size for the header cells than for the body cells. We probably need to do the same for this custom data-table. I've already implemented individual style rules for the header and body cells, but they currently hold the same values. So once @cooper-joe provides the correct values for the header it will be simply a matter of copying these to the stylesheet.
- [ ] Pagination padding values need to be verified by @cooper-joe and adjusted where needed.

---

### Screenshots

*Compact / Small*
<img width="1279" alt="Screenshot 2022-02-24 at 16 57 36" src="https://user-images.githubusercontent.com/353236/155560295-e4534ab7-163a-44fe-a34d-8a7a300dd1d7.png">

*Normal / Normal*
<img width="1281" alt="Screenshot 2022-02-24 at 16 59 20" src="https://user-images.githubusercontent.com/353236/155560489-eef4ccf3-8e3a-4cf5-9007-adc819553adc.png">

*Comfortable / Large*
<img width="1279" alt="Screenshot 2022-02-24 at 17 00 18" src="https://user-images.githubusercontent.com/353236/155560664-dcc9659c-3c1f-4150-a5a0-1396cb43b15c.png">

*Compact / Large*
<img width="1279" alt="Screenshot 2022-02-24 at 17 01 44" src="https://user-images.githubusercontent.com/353236/155560965-52c115a3-e844-4994-b4c1-37a574b12df6.png">
*I've included this one because this unexpected combination actually looks pretty useful*

