### PR TITLE
fix: time and main dimension constants should use _ID_ rather than _TYPE_

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,4 +1,4 @@
-import { DIMENSION_TYPES_PROGRAM } from '../modules/dimensionTypes.js'
+import { DIMENSION_TYPES_PROGRAM } from '../modules/dimensionConstants.js'
 import {
     getDefaulTimeDimensionsMetadata,
     getDynamicTimeDimensionsMetadata,

--- a/src/actions/visualization.js
+++ b/src/actions/visualization.js
@@ -27,6 +27,8 @@ export const acSetVisualization = (value) => {
             }
         })
 
+    console.log('acSetVis meta', metadata)
+
     return {
         type: SET_VISUALIZATION,
         value,

--- a/src/actions/visualization.js
+++ b/src/actions/visualization.js
@@ -27,8 +27,6 @@ export const acSetVisualization = (value) => {
             }
         })
 
-    console.log('acSetVis meta', metadata)
-
     return {
         type: SET_VISUALIZATION,
         value,

--- a/src/api/legendSets.js
+++ b/src/api/legendSets.js
@@ -2,7 +2,7 @@ import {
     DIMENSION_TYPE_DATA_ELEMENT,
     DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
     DIMENSION_TYPE_PROGRAM_INDICATOR,
-} from '../modules/dimensionTypes.js'
+} from '../modules/dimensionConstants.js'
 
 const dataElementsQuery = {
     resource: 'dataElements',

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -191,7 +191,7 @@ const App = ({
                     id,
                     name: item.name || item.displayName,
                     displayName: item.displayName,
-                    dimensionType: item.dimensionItemType,
+                    dimensionType: item.dimensionType || item.dimensionItemType,
                     code: item.code,
                 }
 

--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -12,7 +12,7 @@ import {
 import {
     DIMENSION_TYPE_DATA_ELEMENT,
     DIMENSION_TYPE_PROGRAM_INDICATOR,
-} from '../../../modules/dimensionTypes.js'
+} from '../../../modules/dimensionConstants.js'
 import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetMetadataById } from '../../../reducers/metadata.js'
 import { sGetSettingsDisplayNameProperty } from '../../../reducers/settings.js'

--- a/src/components/Dialogs/DialogManager.js
+++ b/src/components/Dialogs/DialogManager.js
@@ -1,28 +1,20 @@
-import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
 import React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { acSetUiOpenDimensionModal } from '../../actions/ui.js'
 import {
+    DIMENSION_TYPE_OU,
     DIMENSION_TYPE_PERIOD,
     DIMENSION_TYPE_CATEGORY,
     DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET,
-    DIMENSION_TYPE_EVENT_STATUS,
+    DIMENSION_TYPE_STATUS,
     DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-} from '../../modules/dimensionTypes.js'
+} from '../../modules/dimensionConstants.js'
 import { sGetMetadata } from '../../reducers/metadata.js'
 import { sGetUiActiveModalDialog } from '../../reducers/ui.js'
 import ConditionsManager from './Conditions/ConditionsManager.js'
 import DynamicDimension from './DynamicDimension.js'
 import FixedDimension from './FixedDimension.js'
 import PeriodDimension from './PeriodDimension/index.js'
-
-const isDynamicDimension = (type) =>
-    [
-        DIMENSION_TYPE_CATEGORY,
-        DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET,
-        DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET,
-    ].includes(type)
 
 const DialogManager = () => {
     const dispatch = useDispatch()
@@ -32,23 +24,24 @@ const DialogManager = () => {
 
     const onClose = () => dispatch(acSetUiOpenDimensionModal(null))
 
-    if (isDynamicDimension(dimension?.dimensionType)) {
-        return <DynamicDimension dimension={dimension} onClose={onClose} />
+    if (!dimension?.id) {
+        return null
     }
-    if (dimension?.dimensionType === DIMENSION_TYPE_PERIOD) {
-        return <PeriodDimension dimension={dimension} onClose={onClose} />
-    }
-    switch (dimension?.id) {
-        case DIMENSION_TYPE_PROGRAM_STATUS:
-        case DIMENSION_TYPE_EVENT_STATUS:
-        case DIMENSION_ID_ORGUNIT: {
+    switch (dimension.dimensionType) {
+        case DIMENSION_TYPE_CATEGORY:
+        case DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET:
+        case DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET:
+            return <DynamicDimension dimension={dimension} onClose={onClose} />
+
+        case DIMENSION_TYPE_PERIOD:
+            return <PeriodDimension dimension={dimension} onClose={onClose} />
+
+        case DIMENSION_TYPE_STATUS:
+        case DIMENSION_TYPE_OU:
             return <FixedDimension dimension={dimension} onClose={onClose} />
-        }
-        default: {
-            return dimension?.id ? (
-                <ConditionsManager dimension={dimension} onClose={onClose} />
-            ) : null
-        }
+
+        default:
+            return <ConditionsManager dimension={dimension} onClose={onClose} />
     }
 }
 

--- a/src/components/Dialogs/FixedDimension.js
+++ b/src/components/Dialogs/FixedDimension.js
@@ -11,9 +11,9 @@ import { connect } from 'react-redux'
 import { acAddMetadata } from '../../actions/metadata.js'
 import { acSetUiItems, acAddParentGraphMap } from '../../actions/ui.js'
 import {
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-} from '../../modules/dimensionTypes.js'
+    DIMENSION_ID_EVENT_STATUS,
+    DIMENSION_ID_PROGRAM_STATUS,
+} from '../../modules/dimensionConstants.js'
 import { removeLastPathSegment, getOuPath } from '../../modules/orgUnit.js'
 import {
     STATUS_ACTIVE,
@@ -118,7 +118,7 @@ const FixedDimension = ({
                             label={name}
                             onChange={({ checked }) =>
                                 setStatus({
-                                    dimensionId: DIMENSION_TYPE_PROGRAM_STATUS,
+                                    dimensionId: DIMENSION_ID_PROGRAM_STATUS,
                                     selectedItemsIds: programStatusIds,
                                     itemId: id,
                                     toggle: checked,
@@ -150,7 +150,7 @@ const FixedDimension = ({
                             label={name}
                             onChange={({ checked }) =>
                                 setStatus({
-                                    dimensionId: DIMENSION_TYPE_EVENT_STATUS,
+                                    dimensionId: DIMENSION_ID_EVENT_STATUS,
                                     selectedItemsIds: eventStatusIds,
                                     itemId: id,
                                     toggle: checked,
@@ -167,9 +167,9 @@ const FixedDimension = ({
 
     const renderModalContent = () => {
         switch (dimension.id) {
-            case DIMENSION_TYPE_PROGRAM_STATUS:
+            case DIMENSION_ID_PROGRAM_STATUS:
                 return renderProgramStatus()
-            case DIMENSION_TYPE_EVENT_STATUS:
+            case DIMENSION_ID_EVENT_STATUS:
                 return renderEventStatus()
             case DIMENSION_ID_ORGUNIT: {
                 const dimensionProps = {
@@ -243,7 +243,7 @@ FixedDimension.defaultProps = {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-    eventStatusIds: sGetUiItemsByDimension(state, DIMENSION_TYPE_EVENT_STATUS),
+    eventStatusIds: sGetUiItemsByDimension(state, DIMENSION_ID_EVENT_STATUS),
     isInLayout: sGetDimensionIdsFromLayout(state).includes(
         ownProps.dimension?.id
     ),
@@ -252,7 +252,7 @@ const mapStateToProps = (state, ownProps) => ({
     parentGraphMap: sGetUiParentGraphMap(state),
     programStatusIds: sGetUiItemsByDimension(
         state,
-        DIMENSION_TYPE_PROGRAM_STATUS
+        DIMENSION_ID_PROGRAM_STATUS
     ),
     rootOrgUnits: sGetRootOrgUnits(state),
 })

--- a/src/components/Layout/ChipBase.js
+++ b/src/components/Layout/ChipBase.js
@@ -2,7 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import DynamicDimensionIcon from '../../assets/DynamicDimensionIcon.js'
+import { DimensionIcon } from '../MainSidebar/DimensionItem/DimensionIcon.js'
 import styles from './styles/Chip.module.css'
 
 // Presentational component used by dnd - do not add redux or dnd functionality
@@ -24,14 +24,11 @@ const renderChipLabelSuffix = (items, numberOfConditions) => {
 }
 
 export const ChipBase = (props) => {
-    const renderChipIcon = () => {
-        // TODO: Add the chip icons once they've been spec'ed properly
-        return <DynamicDimensionIcon />
-    }
-
     return (
         <div className={cx(styles.chip, styles.chipLeft)}>
-            <div className={styles.leftIconWrapper}>{renderChipIcon()}</div>
+            <div className={styles.leftIconWrapper}>
+                <DimensionIcon dimensionType={props.dimensionType} />
+            </div>
             <span className={styles.label}>{props.dimensionName}</span>
             <span>
                 {renderChipLabelSuffix(props.items, props.numberOfConditions)}
@@ -42,6 +39,7 @@ export const ChipBase = (props) => {
 
 ChipBase.propTypes = {
     dimensionName: PropTypes.string,
+    dimensionType: PropTypes.string,
     items: PropTypes.array,
     numberOfConditions: PropTypes.number,
 }

--- a/src/components/MainSidebar/DimensionItem/DimensionIcon.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionIcon.js
@@ -1,0 +1,62 @@
+import {
+    IconDimensionData16,
+    IconDimensionProgramIndicator16,
+    IconFilter16,
+    IconDimensionCategoryOptionGroupset16,
+    IconDimensionOrgUnitGroupset16,
+    IconDimensionOrgUnit16,
+    IconCheckmarkCircle16,
+    IconUser16,
+    IconCalendar16,
+} from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import DynamicDimensionIcon from '../../../assets/DynamicDimensionIcon.js'
+import {
+    DIMENSION_TYPE_PERIOD,
+    DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET,
+    DIMENSION_TYPE_CATEGORY,
+    DIMENSION_TYPE_DATA_ELEMENT,
+    DIMENSION_TYPE_STATUS,
+    DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET,
+    DIMENSION_TYPE_OU,
+    DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
+    DIMENSION_TYPE_PROGRAM_INDICATOR,
+    DIMENSION_TYPE_USER,
+} from '../../../modules/dimensionConstants.js'
+
+const DIMENSION_TYPE_ICONS = {
+    /**PROGRAM**/
+    [DIMENSION_TYPE_DATA_ELEMENT]: IconDimensionData16,
+    [DIMENSION_TYPE_PROGRAM_ATTRIBUTE]: IconDimensionData16,
+    [DIMENSION_TYPE_PROGRAM_INDICATOR]: IconDimensionProgramIndicator16,
+    [DIMENSION_TYPE_CATEGORY]: IconFilter16,
+    [DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET]:
+        IconDimensionCategoryOptionGroupset16,
+    /**YOURS**/
+    [DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET]:
+        IconDimensionOrgUnitGroupset16,
+    /**MAIN**/
+    [DIMENSION_TYPE_OU]: IconDimensionOrgUnit16,
+    [DIMENSION_TYPE_STATUS]: IconCheckmarkCircle16,
+    [DIMENSION_TYPE_USER]: IconUser16,
+    /**TIME**/
+    [DIMENSION_TYPE_PERIOD]: IconCalendar16,
+}
+
+// Presentational component used by dnd - do not add redux or dnd functionality
+
+const DimensionIcon = ({ dimensionType }) => {
+    const Icon =
+        dimensionType && DIMENSION_TYPE_ICONS[dimensionType]
+            ? DIMENSION_TYPE_ICONS[dimensionType]
+            : DynamicDimensionIcon
+
+    return <Icon />
+}
+
+DimensionIcon.propTypes = {
+    dimensionType: PropTypes.string,
+}
+
+export { DimensionIcon }

--- a/src/components/MainSidebar/DimensionItem/DimensionItemBase.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItemBase.js
@@ -1,54 +1,8 @@
-import {
-    IconDimensionData16,
-    IconDimensionProgramIndicator16,
-    IconFilter16,
-    IconDimensionCategoryOptionGroupset16,
-    IconDimensionOrgUnitGroupset16,
-    IconDimensionOrgUnit16,
-    IconCheckmarkCircle16,
-    IconUser16,
-    IconCalendar16,
-} from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import DynamicDimensionIcon from '../../../assets/DynamicDimensionIcon.js'
-import {
-    DIMENSION_TYPE_PERIOD,
-    DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET,
-    DIMENSION_TYPE_CATEGORY,
-    DIMENSION_TYPE_DATA_ELEMENT,
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_LAST_UPDATED_BY,
-    DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET,
-    DIMENSION_TYPE_OU,
-    DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
-    DIMENSION_TYPE_PROGRAM_INDICATOR,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-    DIMENSION_TYPE_CREATED_BY,
-} from '../../../modules/dimensionTypes.js'
+import { DimensionIcon } from './DimensionIcon.js'
 import styles from './DimensionItemBase.module.css'
-
-const DIMENSION_TYPE_ICONS = {
-    /**PROGRAM**/
-    [DIMENSION_TYPE_DATA_ELEMENT]: IconDimensionData16,
-    [DIMENSION_TYPE_PROGRAM_ATTRIBUTE]: IconDimensionData16,
-    [DIMENSION_TYPE_PROGRAM_INDICATOR]: IconDimensionProgramIndicator16,
-    [DIMENSION_TYPE_CATEGORY]: IconFilter16,
-    [DIMENSION_TYPE_CATEGORY_OPTION_GROUP_SET]:
-        IconDimensionCategoryOptionGroupset16,
-    /**YOURS**/
-    [DIMENSION_TYPE_ORGANISATION_UNIT_GROUP_SET]:
-        IconDimensionOrgUnitGroupset16,
-    /**MAIN**/
-    [DIMENSION_TYPE_OU]: IconDimensionOrgUnit16,
-    [DIMENSION_TYPE_PROGRAM_STATUS]: IconCheckmarkCircle16,
-    [DIMENSION_TYPE_EVENT_STATUS]: IconCheckmarkCircle16,
-    [DIMENSION_TYPE_CREATED_BY]: IconUser16,
-    [DIMENSION_TYPE_LAST_UPDATED_BY]: IconUser16,
-    /**TIME**/
-    [DIMENSION_TYPE_PERIOD]: IconCalendar16,
-}
 
 // Presentational component used by dnd - do not add redux or dnd functionality
 
@@ -61,10 +15,6 @@ const DimensionItemBase = ({
     contextMenu,
     onClick,
 }) => {
-    const Icon = dimensionType
-        ? DIMENSION_TYPE_ICONS[dimensionType]
-        : DynamicDimensionIcon
-
     return (
         <div
             className={cx(styles.dimensionItem, {
@@ -74,7 +24,7 @@ const DimensionItemBase = ({
         >
             <div className={styles.iconAndLabelWrapper} onClick={onClick}>
                 <div className={styles.icon}>
-                    <Icon />
+                    <DimensionIcon dimensionType={dimensionType} />
                 </div>
 
                 <div className={styles.label}>

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsFilter.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsFilter.js
@@ -8,7 +8,7 @@ import {
     DIMENSION_TYPE_ALL,
     DIMENSION_TYPE_PROGRAM_ATTRIBUTE,
     DIMENSION_TYPE_PROGRAM_INDICATOR,
-} from '../../../modules/dimensionTypes.js'
+} from '../../../modules/dimensionConstants.js'
 import { OUTPUT_TYPE_ENROLLMENT } from '../../../modules/visualization.js'
 import { sGetUiInputType } from '../../../reducers/ui.js'
 import styles from './ProgramDimensionsFilter.module.css'

--- a/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/ProgramDimensionsPanel.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { tSetUiProgram } from '../../../actions/ui.js'
-import { DIMENSION_TYPE_ALL } from '../../../modules/dimensionTypes.js'
+import { DIMENSION_TYPE_ALL } from '../../../modules/dimensionConstants.js'
 import {
     PROGRAM_TYPE_WITH_REGISTRATION,
     PROGRAM_TYPE_WITHOUT_REGISTRATION,

--- a/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
+++ b/src/components/MainSidebar/ProgramDimensionsPanel/useProgramDimensions.js
@@ -3,7 +3,7 @@ import { useEffect, useReducer, useCallback, useRef, useMemo } from 'react'
 import {
     DIMENSION_TYPE_ALL,
     DIMENSION_TYPE_DATA_ELEMENT,
-} from '../../../modules/dimensionTypes.js'
+} from '../../../modules/dimensionConstants.js'
 import {
     OUTPUT_TYPE_EVENT,
     OUTPUT_TYPE_ENROLLMENT,

--- a/src/components/MainSidebar/SelectedDimensionsContext.js
+++ b/src/components/MainSidebar/SelectedDimensionsContext.js
@@ -4,7 +4,7 @@ import { useSelector, useStore } from 'react-redux'
 import {
     DIMENSION_TYPES_PROGRAM,
     DIMENSION_TYPES_YOURS,
-} from '../../modules/dimensionTypes.js'
+} from '../../modules/dimensionConstants.js'
 import { sGetUiLayout } from '../../reducers/ui.js'
 
 const SelectedDimensionsContext = createContext({

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -16,9 +16,9 @@ import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { acSetLoadError } from '../../actions/loader.js'
 import {
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-} from '../../modules/dimensionTypes.js'
+    DIMENSION_ID_EVENT_STATUS,
+    DIMENSION_ID_PROGRAM_STATUS,
+} from '../../modules/dimensionConstants.js'
 import { genericServerError, noPeriodError } from '../../modules/error.js'
 import {
     DISPLAY_DENSITY_COMFORTABLE,
@@ -113,8 +113,8 @@ export const Visualization = ({
     const formatCellValue = (value, header) => {
         if (
             [
-                headersMap[DIMENSION_TYPE_EVENT_STATUS],
-                headersMap[DIMENSION_TYPE_PROGRAM_STATUS],
+                headersMap[DIMENSION_ID_EVENT_STATUS],
+                headersMap[DIMENSION_ID_PROGRAM_STATUS],
             ].includes(header?.name)
         ) {
             return metadata[value]?.name || value

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -9,12 +9,12 @@ import i18n from '@dhis2/d2-i18n'
 import { useEffect, useState, useRef, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import {
-    DIMENSION_TYPE_PROGRAM_STATUS,
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_CREATED_BY,
-    DIMENSION_TYPE_LAST_UPDATED_BY,
-    DIMENSION_TYPES_TIME,
-} from '../../modules/dimensionTypes.js'
+    DIMENSION_ID_PROGRAM_STATUS,
+    DIMENSION_ID_EVENT_STATUS,
+    DIMENSION_ID_CREATED_BY,
+    DIMENSION_ID_LAST_UPDATED_BY,
+    DIMENSION_IDS_TIME,
+} from '../../modules/dimensionConstants.js'
 import {
     OUTPUT_TYPE_ENROLLMENT,
     OUTPUT_TYPE_EVENT,
@@ -36,8 +36,8 @@ const analyticsApiEndpointMap = {
 }
 
 const excludedDimensions = [
-    DIMENSION_TYPE_CREATED_BY,
-    DIMENSION_TYPE_LAST_UPDATED_BY,
+    DIMENSION_ID_CREATED_BY,
+    DIMENSION_ID_LAST_UPDATED_BY,
 ]
 
 const findOptionSetItem = (code, metaDataItems) =>
@@ -55,7 +55,7 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
     }
 }
 
-const isTimeDimension = (dimensionId) => DIMENSION_TYPES_TIME.has(dimensionId)
+const isTimeDimension = (dimensionId) => DIMENSION_IDS_TIME.has(dimensionId)
 
 const getAdaptedVisualization = (visualization) => {
     const parameters = {}
@@ -67,8 +67,8 @@ const getAdaptedVisualization = (visualization) => {
 
             if (
                 isTimeDimension(dimensionId) ||
-                dimensionId === DIMENSION_TYPE_EVENT_STATUS ||
-                dimensionId === DIMENSION_TYPE_PROGRAM_STATUS
+                dimensionId === DIMENSION_ID_EVENT_STATUS ||
+                dimensionId === DIMENSION_ID_PROGRAM_STATUS
             ) {
                 parameters[dimensionId] = dimensionObj.items?.map(
                     (item) => item.id

--- a/src/modules/__tests__/timeDimensions.spec.js
+++ b/src/modules/__tests__/timeDimensions.spec.js
@@ -1,10 +1,10 @@
 import {
-    DIMENSION_TYPE_EVENT_DATE,
-    DIMENSION_TYPE_ENROLLMENT_DATE,
-    DIMENSION_TYPE_INCIDENT_DATE,
-    DIMENSION_TYPE_SCHEDULED_DATE,
-    DIMENSION_TYPE_LAST_UPDATED,
-} from '../dimensionTypes.js'
+    DIMENSION_ID_EVENT_DATE,
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_INCIDENT_DATE,
+    DIMENSION_ID_SCHEDULED_DATE,
+    DIMENSION_ID_LAST_UPDATED,
+} from '../dimensionConstants.js'
 import {
     PROGRAM_TYPE_WITH_REGISTRATION,
     PROGRAM_TYPE_WITHOUT_REGISTRATION,
@@ -18,14 +18,13 @@ import { OUTPUT_TYPE_ENROLLMENT, OUTPUT_TYPE_EVENT } from '../visualization.js'
 
 describe('ER > Dimensions > getTimeDimensionName', () => {
     const timeDimensions = getTimeDimensions()
-    const eventDateDimension = timeDimensions[DIMENSION_TYPE_EVENT_DATE]
-    const enrollmentDateDimension =
-        timeDimensions[DIMENSION_TYPE_ENROLLMENT_DATE]
-    const incidentDateDimension = timeDimensions[DIMENSION_TYPE_INCIDENT_DATE]
+    const eventDateDimension = timeDimensions[DIMENSION_ID_EVENT_DATE]
+    const enrollmentDateDimension = timeDimensions[DIMENSION_ID_ENROLLMENT_DATE]
+    const incidentDateDimension = timeDimensions[DIMENSION_ID_INCIDENT_DATE]
     /***** NOT in MVP / 2.38 release *****
-    const scheduledDateDimension = timeDimensions[DIMENSION_TYPE_SCHEDULED_DATE]
+    const scheduledDateDimension = timeDimensions[DIMENSION_ID_SCHEDULED_DATE]
     */
-    const lastUpdatedDimension = timeDimensions[DIMENSION_TYPE_LAST_UPDATED]
+    const lastUpdatedDimension = timeDimensions[DIMENSION_ID_LAST_UPDATED]
 
     it('uses default names normally', () => {
         const program = {
@@ -197,11 +196,11 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 hideDueDate: false,
             },
             expected: [
-                DIMENSION_TYPE_EVENT_DATE,
-                DIMENSION_TYPE_ENROLLMENT_DATE,
-                DIMENSION_TYPE_SCHEDULED_DATE,
-                DIMENSION_TYPE_INCIDENT_DATE,
-                DIMENSION_TYPE_LAST_UPDATED,
+                DIMENSION_ID_EVENT_DATE,
+                DIMENSION_ID_ENROLLMENT_DATE,
+                DIMENSION_ID_SCHEDULED_DATE,
+                DIMENSION_ID_INCIDENT_DATE,
+                DIMENSION_ID_LAST_UPDATED,
             ],
         },
         // Hiding the due date
@@ -216,10 +215,10 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 hideDueDate: true,
             },
             expected: [
-                DIMENSION_TYPE_EVENT_DATE,
-                DIMENSION_TYPE_ENROLLMENT_DATE,
-                DIMENSION_TYPE_INCIDENT_DATE,
-                DIMENSION_TYPE_LAST_UPDATED,
+                DIMENSION_ID_EVENT_DATE,
+                DIMENSION_ID_ENROLLMENT_DATE,
+                DIMENSION_ID_INCIDENT_DATE,
+                DIMENSION_ID_LAST_UPDATED,
             ],
         },
         // Hiding the incident date
@@ -234,9 +233,9 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 hideDueDate: true,
             },
             expected: [
-                DIMENSION_TYPE_EVENT_DATE,
-                DIMENSION_TYPE_ENROLLMENT_DATE,
-                DIMENSION_TYPE_LAST_UPDATED,
+                DIMENSION_ID_EVENT_DATE,
+                DIMENSION_ID_ENROLLMENT_DATE,
+                DIMENSION_ID_LAST_UPDATED,
             ],
         },
         // input type enrollment
@@ -251,9 +250,9 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 hideDueDate: false,
             },
             expected: [
-                DIMENSION_TYPE_ENROLLMENT_DATE,
-                DIMENSION_TYPE_INCIDENT_DATE,
-                DIMENSION_TYPE_LAST_UPDATED,
+                DIMENSION_ID_ENROLLMENT_DATE,
+                DIMENSION_ID_INCIDENT_DATE,
+                DIMENSION_ID_LAST_UPDATED,
             ],
         },
         // Event program
@@ -267,7 +266,7 @@ describe('ER > Dimensions > getEnabledTimeDimensionIds', () => {
                 id: '1',
                 hideDueDate: false,
             },
-            expected: [DIMENSION_TYPE_EVENT_DATE, DIMENSION_TYPE_LAST_UPDATED],
+            expected: [DIMENSION_ID_EVENT_DATE, DIMENSION_ID_LAST_UPDATED],
         },
     ])(
         'returns expected IDs for inputType $inputType, programType $program.programType with displayIncidentDate $program.displayIncidentDate and stage.hideDueDate $stage.hideDueDate',

--- a/src/modules/dimensionConstants.js
+++ b/src/modules/dimensionConstants.js
@@ -27,25 +27,30 @@ export const DIMENSION_TYPES_YOURS = new Set([
 
 /**MAIN**/
 export const DIMENSION_TYPE_OU = 'ORGANISATION_UNIT'
-export const DIMENSION_TYPE_PROGRAM_STATUS = 'programStatus'
-export const DIMENSION_TYPE_EVENT_STATUS = 'eventStatus'
-export const DIMENSION_TYPE_CREATED_BY = 'createdBy'
-export const DIMENSION_TYPE_LAST_UPDATED_BY = 'lastUpdatedBy'
+export const DIMENSION_TYPE_STATUS = 'STATUS'
+export const DIMENSION_TYPE_USER = 'DATA_X'
 
 /**PERIOD - time dimension group name**/
 export const DIMENSION_TYPE_PERIOD = 'PERIOD'
 
-/**TIME - specific time dimensions**/
-export const DIMENSION_TYPE_EVENT_DATE = 'eventDate'
-export const DIMENSION_TYPE_ENROLLMENT_DATE = 'enrollmentDate'
-export const DIMENSION_TYPE_INCIDENT_DATE = 'incidentDate'
-export const DIMENSION_TYPE_SCHEDULED_DATE = 'scheduledDate'
-export const DIMENSION_TYPE_LAST_UPDATED = 'lastUpdated'
+/** DIMENSION_IDS */
 
-export const DIMENSION_TYPES_TIME = new Set([
-    DIMENSION_TYPE_EVENT_DATE,
-    DIMENSION_TYPE_ENROLLMENT_DATE,
-    DIMENSION_TYPE_INCIDENT_DATE,
-    DIMENSION_TYPE_SCHEDULED_DATE,
-    DIMENSION_TYPE_LAST_UPDATED,
+export const DIMENSION_ID_PROGRAM_STATUS = 'programStatus'
+export const DIMENSION_ID_EVENT_STATUS = 'eventStatus'
+export const DIMENSION_ID_CREATED_BY = 'createdBy'
+export const DIMENSION_ID_LAST_UPDATED_BY = 'lastUpdatedBy'
+
+/**TIME - specific time dimensions**/
+export const DIMENSION_ID_EVENT_DATE = 'eventDate'
+export const DIMENSION_ID_ENROLLMENT_DATE = 'enrollmentDate'
+export const DIMENSION_ID_INCIDENT_DATE = 'incidentDate'
+export const DIMENSION_ID_SCHEDULED_DATE = 'scheduledDate'
+export const DIMENSION_ID_LAST_UPDATED = 'lastUpdated'
+
+export const DIMENSION_IDS_TIME = new Set([
+    DIMENSION_ID_EVENT_DATE,
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_INCIDENT_DATE,
+    DIMENSION_ID_SCHEDULED_DATE,
+    DIMENSION_ID_LAST_UPDATED,
 ])

--- a/src/modules/dimensionTypes.js
+++ b/src/modules/dimensionTypes.js
@@ -26,7 +26,7 @@ export const DIMENSION_TYPES_YOURS = new Set([
 ])
 
 /**MAIN**/
-export const DIMENSION_TYPE_OU = 'ou'
+export const DIMENSION_TYPE_OU = 'ORGANISATION_UNIT'
 export const DIMENSION_TYPE_PROGRAM_STATUS = 'programStatus'
 export const DIMENSION_TYPE_EVENT_STATUS = 'eventStatus'
 export const DIMENSION_TYPE_CREATED_BY = 'createdBy'

--- a/src/modules/layoutValidation.js
+++ b/src/modules/layoutValidation.js
@@ -5,7 +5,7 @@ import {
     VIS_TYPE_LINE_LIST,
     DIMENSION_ID_ORGUNIT,
 } from '@dhis2/analytics'
-import { DIMENSION_TYPES_TIME } from './dimensionTypes.js'
+import { DIMENSION_IDS_TIME } from './dimensionConstants.js'
 import {
     noColumnsError,
     noOrgUnitError,
@@ -44,7 +44,7 @@ const validateLineListLayout = (layout) => {
 
     let layoutHasTimeDimension = false
 
-    DIMENSION_TYPES_TIME.forEach((dimensionId) => {
+    DIMENSION_IDS_TIME.forEach((dimensionId) => {
         const dimension = layoutGetDimension(layout, dimensionId)
 
         if (dimension && dimensionIsValid(dimension, { requireItems: true })) {

--- a/src/modules/mainDimensions.js
+++ b/src/modules/mainDimensions.js
@@ -1,3 +1,4 @@
+import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import {
     DIMENSION_TYPE_OU,
@@ -10,8 +11,8 @@ import { PROGRAM_TYPE_WITHOUT_REGISTRATION } from './programTypes.js'
 import { OUTPUT_TYPE_ENROLLMENT } from './visualization.js'
 
 export const getMainDimensions = () => ({
-    [DIMENSION_TYPE_OU]: {
-        id: DIMENSION_TYPE_OU,
+    [DIMENSION_ID_ORGUNIT]: {
+        id: DIMENSION_ID_ORGUNIT,
         dimensionType: DIMENSION_TYPE_OU,
         name: i18n.t('Organisation unit'),
     },

--- a/src/modules/mainDimensions.js
+++ b/src/modules/mainDimensions.js
@@ -40,14 +40,14 @@ export const getMainDimensions = () => ({
     },
 })
 
-export const getIsMainDimensionDisabled = (
-    dimensionType,
+export const getIsMainDimensionDisabled = ({
+    dimensionId,
     inputType,
-    programType
-) => {
-    if (dimensionType === DIMENSION_ID_PROGRAM_STATUS) {
+    programType,
+}) => {
+    if (dimensionId === DIMENSION_ID_PROGRAM_STATUS) {
         return !programType || programType === PROGRAM_TYPE_WITHOUT_REGISTRATION
-    } else if (dimensionType === DIMENSION_ID_EVENT_STATUS) {
+    } else if (dimensionId === DIMENSION_ID_EVENT_STATUS) {
         return !programType || inputType === OUTPUT_TYPE_ENROLLMENT
     } else {
         return false

--- a/src/modules/mainDimensions.js
+++ b/src/modules/mainDimensions.js
@@ -2,11 +2,13 @@ import { DIMENSION_ID_ORGUNIT } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import {
     DIMENSION_TYPE_OU,
-    DIMENSION_TYPE_CREATED_BY,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_LAST_UPDATED_BY,
-} from './dimensionTypes.js'
+    DIMENSION_ID_CREATED_BY,
+    DIMENSION_ID_PROGRAM_STATUS,
+    DIMENSION_ID_EVENT_STATUS,
+    DIMENSION_ID_LAST_UPDATED_BY,
+    DIMENSION_TYPE_STATUS,
+    DIMENSION_TYPE_USER,
+} from './dimensionConstants.js'
 import { PROGRAM_TYPE_WITHOUT_REGISTRATION } from './programTypes.js'
 import { OUTPUT_TYPE_ENROLLMENT } from './visualization.js'
 
@@ -16,24 +18,24 @@ export const getMainDimensions = () => ({
         dimensionType: DIMENSION_TYPE_OU,
         name: i18n.t('Organisation unit'),
     },
-    [DIMENSION_TYPE_PROGRAM_STATUS]: {
-        id: DIMENSION_TYPE_PROGRAM_STATUS,
-        dimensionType: DIMENSION_TYPE_PROGRAM_STATUS,
+    [DIMENSION_ID_PROGRAM_STATUS]: {
+        id: DIMENSION_ID_PROGRAM_STATUS,
+        dimensionType: DIMENSION_TYPE_STATUS,
         name: i18n.t('Program status'),
     },
-    [DIMENSION_TYPE_EVENT_STATUS]: {
-        id: DIMENSION_TYPE_EVENT_STATUS,
-        dimensionType: DIMENSION_TYPE_EVENT_STATUS,
+    [DIMENSION_ID_EVENT_STATUS]: {
+        id: DIMENSION_ID_EVENT_STATUS,
+        dimensionType: DIMENSION_TYPE_STATUS,
         name: i18n.t('Event status'),
     },
-    [DIMENSION_TYPE_CREATED_BY]: {
-        id: DIMENSION_TYPE_CREATED_BY,
-        dimensionType: DIMENSION_TYPE_CREATED_BY,
+    [DIMENSION_ID_CREATED_BY]: {
+        id: DIMENSION_ID_CREATED_BY,
+        dimensionType: DIMENSION_TYPE_USER,
         name: i18n.t('Created by'),
     },
-    [DIMENSION_TYPE_LAST_UPDATED_BY]: {
-        id: DIMENSION_TYPE_LAST_UPDATED_BY,
-        dimensionType: DIMENSION_TYPE_LAST_UPDATED_BY,
+    [DIMENSION_ID_LAST_UPDATED_BY]: {
+        id: DIMENSION_ID_LAST_UPDATED_BY,
+        dimensionType: DIMENSION_TYPE_USER,
         name: i18n.t('Last updated by'),
     },
 })
@@ -43,9 +45,9 @@ export const getIsMainDimensionDisabled = (
     inputType,
     programType
 ) => {
-    if (dimensionType === DIMENSION_TYPE_PROGRAM_STATUS) {
+    if (dimensionType === DIMENSION_ID_PROGRAM_STATUS) {
         return !programType || programType === PROGRAM_TYPE_WITHOUT_REGISTRATION
-    } else if (dimensionType === DIMENSION_TYPE_EVENT_STATUS) {
+    } else if (dimensionType === DIMENSION_ID_EVENT_STATUS) {
         return !programType || inputType === OUTPUT_TYPE_ENROLLMENT
     } else {
         return false

--- a/src/modules/metadata.js
+++ b/src/modules/metadata.js
@@ -6,7 +6,7 @@ import {
     getDimensionById,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import { DIMENSION_TYPE_OU } from './dimensionTypes.js'
+import { DIMENSION_TYPE_OU } from './dimensionConstants.js'
 import { getMainDimensions } from './mainDimensions.js'
 import { getTimeDimensions, getTimeDimensionName } from './timeDimensions.js'
 import { statusNames } from './visualization.js'

--- a/src/modules/metadata.js
+++ b/src/modules/metadata.js
@@ -6,6 +6,7 @@ import {
     getDimensionById,
 } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
+import { DIMENSION_TYPE_OU } from './dimensionTypes.js'
 import { getMainDimensions } from './mainDimensions.js'
 import { getTimeDimensions, getTimeDimensionName } from './timeDimensions.js'
 import { statusNames } from './visualization.js'
@@ -23,7 +24,10 @@ const getOrganisationUnits = () => ({
 })
 
 const getFixedDimensions = () => ({
-    [DIMENSION_ID_ORGUNIT]: getDimensionById(DIMENSION_ID_ORGUNIT),
+    [DIMENSION_ID_ORGUNIT]: {
+        ...getDimensionById(DIMENSION_ID_ORGUNIT),
+        dimensionType: DIMENSION_TYPE_OU,
+    },
 })
 
 export const getDefaultMetadata = () => ({

--- a/src/modules/timeDimensions.js
+++ b/src/modules/timeDimensions.js
@@ -76,7 +76,7 @@ export const getEnabledTimeDimensionIds = (inputType, program, stage) => {
         }
 
         if (isEnrollment) {
-            enabledDimensionIds.add(DIMENSION_TYPE_ENROLLMENT_DATE)
+            enabledDimensionIds.add(DIMENSION_ID_ENROLLMENT_DATE)
         }
 
         if (withRegistration) {

--- a/src/modules/timeDimensions.js
+++ b/src/modules/timeDimensions.js
@@ -1,12 +1,12 @@
 import i18n from '@dhis2/d2-i18n'
 import {
     DIMENSION_TYPE_PERIOD,
-    DIMENSION_TYPE_EVENT_DATE,
-    DIMENSION_TYPE_ENROLLMENT_DATE,
-    DIMENSION_TYPE_INCIDENT_DATE,
-    DIMENSION_TYPE_SCHEDULED_DATE,
-    DIMENSION_TYPE_LAST_UPDATED,
-} from './dimensionTypes.js'
+    DIMENSION_ID_EVENT_DATE,
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_INCIDENT_DATE,
+    DIMENSION_ID_SCHEDULED_DATE,
+    DIMENSION_ID_LAST_UPDATED,
+} from './dimensionConstants.js'
 import { PROGRAM_TYPE_WITH_REGISTRATION } from './programTypes.js'
 import { OUTPUT_TYPE_EVENT } from './visualization.js'
 
@@ -14,38 +14,38 @@ const NAME_PARENT_PROPERTY_PROGRAM = 'program'
 const NAME_PARENT_PROPERTY_STAGE = 'stage'
 
 export const getTimeDimensions = () => ({
-    [DIMENSION_TYPE_EVENT_DATE]: {
-        id: DIMENSION_TYPE_EVENT_DATE,
+    [DIMENSION_ID_EVENT_DATE]: {
+        id: DIMENSION_ID_EVENT_DATE,
         dimensionType: DIMENSION_TYPE_PERIOD,
         name: i18n.t('Event date'),
         nameParentProperty: NAME_PARENT_PROPERTY_STAGE,
         nameProperty: 'displayExecutionDateLabel',
     },
-    [DIMENSION_TYPE_ENROLLMENT_DATE]: {
-        id: DIMENSION_TYPE_ENROLLMENT_DATE,
+    [DIMENSION_ID_ENROLLMENT_DATE]: {
+        id: DIMENSION_ID_ENROLLMENT_DATE,
         dimensionType: DIMENSION_TYPE_PERIOD,
         name: i18n.t('Enrollment date'),
         nameParentProperty: NAME_PARENT_PROPERTY_PROGRAM,
         nameProperty: 'displayEnrollmentDateLabel',
     },
-    [DIMENSION_TYPE_INCIDENT_DATE]: {
-        id: DIMENSION_TYPE_INCIDENT_DATE,
+    [DIMENSION_ID_INCIDENT_DATE]: {
+        id: DIMENSION_ID_INCIDENT_DATE,
         dimensionType: DIMENSION_TYPE_PERIOD,
         name: i18n.t('Incident date'),
         nameParentProperty: NAME_PARENT_PROPERTY_PROGRAM,
         nameProperty: 'displayIncidentDateLabel',
     },
     /***** NOT in MVP / 2.38 release *****
-    [DIMENSION_TYPE_SCHEDULED_DATE]: {
-        id: DIMENSION_TYPE_SCHEDULED_DATE,
+    [DIMENSION_ID_SCHEDULED_DATE]: {
+        id: DIMENSION_ID_SCHEDULED_DATE,
         dimensionType: DIMENSION_TYPE_PERIOD,
         name: i18n.t('Due/Scheduled date'),
         nameParentProperty: NAME_PARENT_PROPERTY_STAGE,
         nameProperty: 'displayDueDateLabel',
     },
     */
-    [DIMENSION_TYPE_LAST_UPDATED]: {
-        id: DIMENSION_TYPE_LAST_UPDATED,
+    [DIMENSION_ID_LAST_UPDATED]: {
+        id: DIMENSION_ID_LAST_UPDATED,
         dimensionType: DIMENSION_TYPE_PERIOD,
         name: i18n.t('Last updated on'),
     },
@@ -71,22 +71,22 @@ export const getEnabledTimeDimensionIds = (inputType, program, stage) => {
             program?.programType === PROGRAM_TYPE_WITH_REGISTRATION
 
         if (isEvent) {
-            enabledDimensionIds.add(DIMENSION_TYPE_EVENT_DATE)
+            enabledDimensionIds.add(DIMENSION_ID_EVENT_DATE)
         }
 
         if (withRegistration) {
-            enabledDimensionIds.add(DIMENSION_TYPE_ENROLLMENT_DATE)
+            enabledDimensionIds.add(DIMENSION_ID_ENROLLMENT_DATE)
 
             if (isEvent && stage && !stage.hideDueDate) {
-                enabledDimensionIds.add(DIMENSION_TYPE_SCHEDULED_DATE)
+                enabledDimensionIds.add(DIMENSION_ID_SCHEDULED_DATE)
             }
 
             program.displayIncidentDate &&
-                enabledDimensionIds.add(DIMENSION_TYPE_INCIDENT_DATE)
+                enabledDimensionIds.add(DIMENSION_ID_INCIDENT_DATE)
         }
 
         if (isEvent || withRegistration) {
-            enabledDimensionIds.add(DIMENSION_TYPE_LAST_UPDATED)
+            enabledDimensionIds.add(DIMENSION_ID_LAST_UPDATED)
         }
     }
     return enabledDimensionIds

--- a/src/modules/visualization.js
+++ b/src/modules/visualization.js
@@ -12,17 +12,17 @@ import { DEFAULT_CURRENT } from '../reducers/current.js'
 import { DEFAULT_VISUALIZATION } from '../reducers/visualization.js'
 import {
     DIMENSION_TYPE_PERIOD,
-    DIMENSION_TYPE_CREATED_BY,
+    DIMENSION_ID_CREATED_BY,
     DIMENSION_TYPE_DATA_ELEMENT,
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_EVENT_DATE,
-    DIMENSION_TYPE_ENROLLMENT_DATE,
-    DIMENSION_TYPE_INCIDENT_DATE,
-    DIMENSION_TYPE_SCHEDULED_DATE,
-    DIMENSION_TYPE_LAST_UPDATED,
-    DIMENSION_TYPE_LAST_UPDATED_BY,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-} from './dimensionTypes.js'
+    DIMENSION_ID_EVENT_STATUS,
+    DIMENSION_ID_EVENT_DATE,
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_INCIDENT_DATE,
+    DIMENSION_ID_SCHEDULED_DATE,
+    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_LAST_UPDATED_BY,
+    DIMENSION_ID_PROGRAM_STATUS,
+} from './dimensionConstants.js'
 import { default as options } from './options.js'
 
 export const STATUS_ACTIVE = 'ACTIVE'
@@ -40,15 +40,15 @@ export const statusNames = {
 
 export const headersMap = {
     [DIMENSION_ID_ORGUNIT]: 'ouname',
-    [DIMENSION_TYPE_PROGRAM_STATUS]: 'programstatus',
-    [DIMENSION_TYPE_EVENT_STATUS]: 'eventstatus',
-    [DIMENSION_TYPE_CREATED_BY]: 'createdbydisplayname',
-    [DIMENSION_TYPE_LAST_UPDATED_BY]: 'lastupdatedbydisplayname',
-    [DIMENSION_TYPE_EVENT_DATE]: 'eventdate',
-    [DIMENSION_TYPE_ENROLLMENT_DATE]: 'enrollmentdate',
-    [DIMENSION_TYPE_INCIDENT_DATE]: 'incidentdate',
-    [DIMENSION_TYPE_SCHEDULED_DATE]: 'scheduleddate',
-    [DIMENSION_TYPE_LAST_UPDATED]: 'lastupdated',
+    [DIMENSION_ID_PROGRAM_STATUS]: 'programstatus',
+    [DIMENSION_ID_EVENT_STATUS]: 'eventstatus',
+    [DIMENSION_ID_CREATED_BY]: 'createdbydisplayname',
+    [DIMENSION_ID_LAST_UPDATED_BY]: 'lastupdatedbydisplayname',
+    [DIMENSION_ID_EVENT_DATE]: 'eventdate',
+    [DIMENSION_ID_ENROLLMENT_DATE]: 'enrollmentdate',
+    [DIMENSION_ID_INCIDENT_DATE]: 'incidentdate',
+    [DIMENSION_ID_SCHEDULED_DATE]: 'scheduleddate',
+    [DIMENSION_ID_LAST_UPDATED]: 'lastupdated',
 }
 
 export const outputTypeMap = {
@@ -65,8 +65,8 @@ export const outputTypeMap = {
 }
 
 export const outputTypeTimeDimensionMap = {
-    [OUTPUT_TYPE_EVENT]: DIMENSION_TYPE_EVENT_DATE,
-    [OUTPUT_TYPE_ENROLLMENT]: DIMENSION_TYPE_ENROLLMENT_DATE,
+    [OUTPUT_TYPE_EVENT]: DIMENSION_ID_EVENT_DATE,
+    [OUTPUT_TYPE_ENROLLMENT]: DIMENSION_ID_ENROLLMENT_DATE,
 }
 
 export const transformVisualization = (visualization) => {
@@ -89,7 +89,7 @@ export const transformVisualization = (visualization) => {
         visualization.outputType === OUTPUT_TYPE_EVENT
     ) {
         transformedFilters.push({
-            dimension: DIMENSION_TYPE_EVENT_STATUS,
+            dimension: DIMENSION_ID_EVENT_STATUS,
             items: [{ id: STATUS_COMPLETED }],
         })
     }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -379,11 +379,11 @@ export const useMainDimensions = () => {
 
         return Object.values(getMainDimensions()).map((dimension) => ({
             ...dimension,
-            disabled: getIsMainDimensionDisabled(
-                dimension.id,
+            disabled: getIsMainDimensionDisabled({
+                dimensionId: dimension.id,
                 inputType,
-                programType
-            ),
+                programType,
+            }),
         }))
     }, [programId, inputType])
 }

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -6,14 +6,14 @@ import {
 import { useMemo } from 'react'
 import { useStore, useSelector } from 'react-redux'
 import {
-    DIMENSION_TYPE_EVENT_DATE,
-    DIMENSION_TYPE_ENROLLMENT_DATE,
-    DIMENSION_TYPE_INCIDENT_DATE,
-    DIMENSION_TYPE_SCHEDULED_DATE,
-    DIMENSION_TYPE_LAST_UPDATED,
-    DIMENSION_TYPE_EVENT_STATUS,
-    DIMENSION_TYPE_PROGRAM_STATUS,
-} from '../modules/dimensionTypes.js'
+    DIMENSION_ID_EVENT_DATE,
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_INCIDENT_DATE,
+    DIMENSION_ID_SCHEDULED_DATE,
+    DIMENSION_ID_LAST_UPDATED,
+    DIMENSION_ID_EVENT_STATUS,
+    DIMENSION_ID_PROGRAM_STATUS,
+} from '../modules/dimensionConstants.js'
 import { getFilteredLayout } from '../modules/layout.js'
 import {
     getMainDimensions,
@@ -77,14 +77,14 @@ export const DEFAULT_UI = {
     program: {},
     layout: {
         // TODO: Populate the layout with the correct default dimensions, these are just temporary for testing
-        columns: [DIMENSION_ID_ORGUNIT, DIMENSION_TYPE_EVENT_DATE],
+        columns: [DIMENSION_ID_ORGUNIT, DIMENSION_ID_EVENT_DATE],
         filters: [],
     },
     itemsByDimension: {
         [DIMENSION_ID_ORGUNIT]: [],
-        [DIMENSION_TYPE_EVENT_DATE]: ['THIS_MONTH'],
-        [DIMENSION_TYPE_EVENT_STATUS]: [],
-        [DIMENSION_TYPE_PROGRAM_STATUS]: [],
+        [DIMENSION_ID_EVENT_DATE]: ['THIS_MONTH'],
+        [DIMENSION_ID_EVENT_STATUS]: [],
+        [DIMENSION_ID_PROGRAM_STATUS]: [],
     },
     options: getOptionsForUi(),
     showAccessoryPanel: false,
@@ -394,19 +394,19 @@ export const useTimeDimensions = () => {
     const programId = useSelector(sGetUiProgramId)
     const programStageId = useSelector(sGetUiProgramStageId)
     const eventDateDim = useSelector((state) =>
-        sGetMetadataById(state, DIMENSION_TYPE_EVENT_DATE)
+        sGetMetadataById(state, DIMENSION_ID_EVENT_DATE)
     )
     const enrollmentDateDim = useSelector((state) =>
-        sGetMetadataById(state, DIMENSION_TYPE_ENROLLMENT_DATE)
+        sGetMetadataById(state, DIMENSION_ID_ENROLLMENT_DATE)
     )
     const incidentDateDim = useSelector((state) =>
-        sGetMetadataById(state, DIMENSION_TYPE_INCIDENT_DATE)
+        sGetMetadataById(state, DIMENSION_ID_INCIDENT_DATE)
     )
     const scheduledDateDim = useSelector((state) =>
-        sGetMetadataById(state, DIMENSION_TYPE_SCHEDULED_DATE)
+        sGetMetadataById(state, DIMENSION_ID_SCHEDULED_DATE)
     )
     const lastUpdatedDim = useSelector((state) =>
-        sGetMetadataById(state, DIMENSION_TYPE_LAST_UPDATED)
+        sGetMetadataById(state, DIMENSION_ID_LAST_UPDATED)
     )
 
     return useMemo(() => {


### PR DESCRIPTION
1. Rename constants from "_TYPE_" to "_ID_" to clearly differentiate between them (and rename file dimensionTypes.js to dimensionConstants.js)
2. create 2 dimension Types for determining dimension icon and which modal to open: DIMENSION_TYPE_STATUS and DIMENSION_TYPE_USER 
3. DialogManager now only considers dimensionType when deciding which modal to open
4. Set correct dimension icon on chips

![image](https://user-images.githubusercontent.com/6113918/155715173-0feae0ac-c760-4c1b-841e-0220bec923ba.png)