### PR TITLE
fix: add metadata for default period TECH-989

### DIFF
--- a/src/modules/metadata.js
+++ b/src/modules/metadata.js
@@ -27,6 +27,8 @@ const getFixedDimensions = () => ({
 })
 
 export const getDefaultMetadata = () => ({
+    // default selected period
+    THIS_MONTH: { name: i18n.t('This month') },
     ...getMainDimensions(),
     ...getDefaulTimeDimensionsMetadata(),
     ...getFixedDimensions(),


### PR DESCRIPTION
Implements [TECH-989](https://jira.dhis2.org/browse/TECH-989)

---

### Key features

1. add missing metadata for THIS_MONTH

---

### Description

THIS_MONTH is the default item selected for the period dimension. ie. when you click New or start the app without a id in the URL.


### Screenshots

Before:
<img width="532" alt="Screenshot 2022-02-25 at 11 32 04" src="https://user-images.githubusercontent.com/150978/155700060-d15f65ab-96e4-4a88-ab6c-f87930240103.png">

After:
<img width="565" alt="Screenshot 2022-02-25 at 11 32 33" src="https://user-images.githubusercontent.com/150978/155700169-4ff2a774-1c76-40c4-8fdc-5f759efb2441.png">

