### PR TITLE
fix: reset app when New is clicked

### DIFF
--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -6,7 +6,6 @@ import thunk from 'redux-thunk'
 import App from './components/App.js'
 import configureStore from './configureStore.js'
 import metadataMiddleware from './middleware/metadata.js'
-import history from './modules/history.js'
 import './locales/index.js'
 
 const query = {
@@ -65,7 +64,7 @@ const AppWrapper = () => {
                 query={query}
                 dataTransformation={providerDataTransformation}
             >
-                <App initialLocation={history.location} />
+                <App />
             </CachedDataQueryProvider>
         </ReduxProvider>
     )

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -104,7 +104,6 @@ const dataStatisticsMutation = {
 }
 
 const App = ({
-    initialLocation,
     current,
     addMetadata,
     addParentGraphMap,
@@ -126,9 +125,7 @@ const App = ({
     const [data, setData] = useState()
     const [fetchError, setFetchError] = useState()
     const { currentUser, userSettings } = useCachedDataQuery()
-    const [previousLocation, setPreviousLocation] = useState(
-        initialLocation.pathname
-    )
+    const [previousLocation, setPreviousLocation] = useState()
     const [initialLoadIsComplete, setInitialLoadIsComplete] = useState(false)
     const [postDataStatistics] = useDataMutation(dataStatisticsMutation)
     const dispatch = useDispatch()
@@ -218,8 +215,7 @@ const App = ({
             })
 
             setInitMetadata()
-
-            loadVisualization(initialLocation)
+            loadVisualization(history.location)
         }
 
         onMount()
@@ -384,7 +380,6 @@ App.propTypes = {
     clearLoadError: PropTypes.func,
     current: PropTypes.object,
     error: PropTypes.object,
-    initialLocation: PropTypes.object,
     isLoading: PropTypes.bool,
     setCurrent: PropTypes.func,
     setInitMetadata: PropTypes.func,


### PR DESCRIPTION
Implements [TECH-998](https://jira.dhis2.org/browse/TECH-998)

---

### Key features

1. click on New should reset the app

---

### Description

Before it only happened on the 2nd click on New.
I'm not sure about the logic of the navigation, while debugging I
noticed that `previousLocation` is always `undefined` on the next
navigation, so the whole thing seems to work only because we use
location state which covers the cases where the URL remains the same (ie. open the same AO from the FileMenu, click on New multiple times...) but we still want to refresh the page.
The other case is to load the visualization when the location changes,
and that check is always true due to `previousLocation` being `undefined` and compared to `/` or `/[id]`.

This fixes the issue, and everything seems to work, but the logic needs to be reviewed.

Also, before we passed `initialLocation` to `App.js` which seems unnecessary because `history.location` can be read directly in `App.js`. I was actually wondering if passing this prop can cause re-renders of App.js whenever `history.location` changes, we don't really want to re-render `App.js`, just call `loadVisualization` when `history.location` changes.

### Screenshots

Before: notice the correct URL after clicking New but the app still has the state from the previous AO
<img width="986" alt="Screenshot 2022-02-25 at 12 39 33" src="https://user-images.githubusercontent.com/150978/155709211-6cfabdee-8ae7-4c16-ad1e-3ee83c9c41ef.png">


After:
<img width="1158" alt="Screenshot 2022-02-25 at 12 38 48" src="https://user-images.githubusercontent.com/150978/155709121-73d27f00-286d-4334-9697-7cd774520c29.png">

