### PR TITLE
fix: avoid warning about failed prop type

### DIFF
--- a/src/components/MainSidebar/YourDimensionsMenuItem.js
+++ b/src/components/MainSidebar/YourDimensionsMenuItem.js
@@ -36,7 +36,7 @@ export const YourDimensionsMenuItem = ({ selected, count, onClick }) => {
 }
 
 YourDimensionsMenuItem.propTypes = {
-    count: PropTypes.number.isRequired,
-    selected: PropTypes.bool.isRequired,
     onClick: PropTypes.func.isRequired,
+    count: PropTypes.number,
+    selected: PropTypes.bool,
 }


### PR DESCRIPTION

### Key features

1. `selected` prop was required but its value can be `undefined`

---

### Description

The `selected` prop was throwing a warning about being required but its
value being undefined.
Use the same prop types definitions as in `MenuItem`.

<img width="933" alt="Screenshot 2022-02-25 at 12 55 37" src="https://user-images.githubusercontent.com/150978/155711215-a27f10cb-c368-473f-be75-6a4827d7c096.png">