### PR TITLE
fix: add dimension to metadata when adding from chip menu

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-24T10:56:43.943Z\n"
-"PO-Revision-Date: 2022-02-24T10:56:43.943Z\n"
+"POT-Creation-Date: 2022-02-28T10:52:27.426Z\n"
+"PO-Revision-Date: 2022-02-28T10:52:27.426Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -657,6 +657,9 @@ msgstr "User sub-units"
 
 msgid "User sub-x2-units"
 msgstr "User sub-x2-units"
+
+msgid "This month"
+msgstr "This month"
 
 msgid "Table title"
 msgstr "Table title"

--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -156,9 +156,10 @@ export const acSetUiOption = (value) => ({
     value,
 })
 
-export const acAddUiLayoutDimensions = (value) => ({
+export const acAddUiLayoutDimensions = (value, metadata) => ({
     type: ADD_UI_LAYOUT_DIMENSIONS,
     value,
+    metadata,
 })
 
 export const acRemoveUiLayoutDimensions = (value) => ({

--- a/src/components/DimensionMenu/DimensionMenu.js
+++ b/src/components/DimensionMenu/DimensionMenu.js
@@ -18,7 +18,7 @@ const getAxisIdForDimension = (dimensionId, layout) => {
     return axisLayout ? axisLayout[0] : undefined
 }
 
-const DimensionMenu = ({ currentAxisId, dimensionId, onAxisItemClick }) => {
+const DimensionMenu = ({ currentAxisId, dimensionId, dimensionMetadata }) => {
     const dispatch = useDispatch()
     const visType = useSelector(sGetUiType)
     const layout = useSelector(sGetUiLayout)
@@ -33,7 +33,12 @@ const DimensionMenu = ({ currentAxisId, dimensionId, onAxisItemClick }) => {
     const getMenuId = () => `menu-for-${dimensionId}`
 
     const axisItemHandler = ({ dimensionId, axisId }) => {
-        dispatch(acAddUiLayoutDimensions({ [dimensionId]: { axisId } }))
+        dispatch(
+            acAddUiLayoutDimensions(
+                { [dimensionId]: { axisId } },
+                dimensionMetadata
+            )
+        )
     }
 
     const removeItemHandler = (id) => dispatch(acRemoveUiLayoutDimensions(id))
@@ -57,7 +62,7 @@ const DimensionMenu = ({ currentAxisId, dimensionId, onAxisItemClick }) => {
                             dimensionId={dimensionId}
                             currentAxisId={axisId}
                             visType={visType}
-                            axisItemHandler={onAxisItemClick || axisItemHandler}
+                            axisItemHandler={axisItemHandler}
                             removeItemHandler={removeItemHandler}
                             onClose={toggleMenu}
                             dataTest={'layout-dimension-menu-dimension-menu'}
@@ -72,7 +77,7 @@ const DimensionMenu = ({ currentAxisId, dimensionId, onAxisItemClick }) => {
 DimensionMenu.propTypes = {
     currentAxisId: PropTypes.string,
     dimensionId: PropTypes.string,
-    onAxisItemClick: PropTypes.func,
+    dimensionMetadata: PropTypes.obj,
 }
 
 export default DimensionMenu

--- a/src/components/DimensionMenu/DimensionMenu.js
+++ b/src/components/DimensionMenu/DimensionMenu.js
@@ -18,7 +18,7 @@ const getAxisIdForDimension = (dimensionId, layout) => {
     return axisLayout ? axisLayout[0] : undefined
 }
 
-const DimensionMenu = ({ currentAxisId, dimensionId }) => {
+const DimensionMenu = ({ currentAxisId, dimensionId, onAxisItemClick }) => {
     const dispatch = useDispatch()
     const visType = useSelector(sGetUiType)
     const layout = useSelector(sGetUiLayout)
@@ -57,7 +57,7 @@ const DimensionMenu = ({ currentAxisId, dimensionId }) => {
                             dimensionId={dimensionId}
                             currentAxisId={axisId}
                             visType={visType}
-                            axisItemHandler={axisItemHandler}
+                            axisItemHandler={onAxisItemClick || axisItemHandler}
                             removeItemHandler={removeItemHandler}
                             onClose={toggleMenu}
                             dataTest={'layout-dimension-menu-dimension-menu'}
@@ -72,6 +72,7 @@ const DimensionMenu = ({ currentAxisId, dimensionId }) => {
 DimensionMenu.propTypes = {
     currentAxisId: PropTypes.string,
     dimensionId: PropTypes.string,
+    onAxisItemClick: PropTypes.func,
 }
 
 export default DimensionMenu

--- a/src/components/MainSidebar/DimensionItem/DimensionItem.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItem.js
@@ -59,11 +59,7 @@ export const DimensionItem = ({
     } = useSortable({
         id: draggableId || id,
         disabled: disabled || selected,
-        data: {
-            name,
-            dimensionType,
-            valueType,
-        },
+        data: dimensionMetadata,
     })
 
     const style = transform

--- a/src/components/MainSidebar/DimensionItem/DimensionItem.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItem.js
@@ -3,10 +3,7 @@ import { CSS } from '@dnd-kit/utilities'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useDispatch } from 'react-redux'
-import {
-    acSetUiOpenDimensionModal,
-    acAddUiLayoutDimensions,
-} from '../../../actions/ui.js'
+import { acSetUiOpenDimensionModal } from '../../../actions/ui.js'
 import DimensionMenu from '../../DimensionMenu/DimensionMenu.js'
 import { DimensionItemBase } from './DimensionItemBase.js'
 
@@ -36,15 +33,6 @@ export const DimensionItem = ({
     const onClick = disabled
         ? undefined
         : () => dispatch(acSetUiOpenDimensionModal(id, dimensionMetadata))
-
-    const onAxisItemClick = ({ dimensionId, axisId }) => {
-        dispatch(
-            acAddUiLayoutDimensions(
-                { [dimensionId]: { axisId } },
-                dimensionMetadata
-            )
-        )
-    }
 
     const onMouseOver = () => setMouseIsOver(true)
     const onMouseExit = () => setMouseIsOver(false)
@@ -96,7 +84,7 @@ export const DimensionItem = ({
                     mouseIsOver && !disabled ? (
                         <DimensionMenu
                             dimensionId={id}
-                            onAxisItemClick={onAxisItemClick}
+                            dimensionMetadata={dimensionMetadata}
                         />
                     ) : null
                 }

--- a/src/components/MainSidebar/DimensionItem/DimensionItem.js
+++ b/src/components/MainSidebar/DimensionItem/DimensionItem.js
@@ -3,7 +3,10 @@ import { CSS } from '@dnd-kit/utilities'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { acSetUiOpenDimensionModal } from '../../../actions/ui.js'
+import {
+    acSetUiOpenDimensionModal,
+    acAddUiLayoutDimensions,
+} from '../../../actions/ui.js'
 import DimensionMenu from '../../DimensionMenu/DimensionMenu.js'
 import { DimensionItemBase } from './DimensionItemBase.js'
 
@@ -20,20 +23,28 @@ export const DimensionItem = ({
 }) => {
     const dispatch = useDispatch()
     const [mouseIsOver, setMouseIsOver] = useState(false)
+    const dimensionMetadata = {
+        [id]: {
+            id,
+            name,
+            dimensionType,
+            valueType,
+            optionSet,
+        },
+    }
+
     const onClick = disabled
         ? undefined
-        : () =>
-              dispatch(
-                  acSetUiOpenDimensionModal(id, {
-                      [id]: {
-                          id,
-                          name,
-                          dimensionType,
-                          valueType,
-                          optionSet,
-                      },
-                  })
-              )
+        : () => dispatch(acSetUiOpenDimensionModal(id, dimensionMetadata))
+
+    const onAxisItemClick = ({ dimensionId, axisId }) => {
+        dispatch(
+            acAddUiLayoutDimensions(
+                { [dimensionId]: { axisId } },
+                dimensionMetadata
+            )
+        )
+    }
 
     const onMouseOver = () => setMouseIsOver(true)
     const onMouseExit = () => setMouseIsOver(false)
@@ -87,7 +98,10 @@ export const DimensionItem = ({
                 onClick={onClick}
                 contextMenu={
                     mouseIsOver && !disabled ? (
-                        <DimensionMenu dimensionId={id} />
+                        <DimensionMenu
+                            dimensionId={id}
+                            onAxisItemClick={onAxisItemClick}
+                        />
                     ) : null
                 }
             />


### PR DESCRIPTION
Implements KMFT issue, see [Slack thread](https://dhis2.slack.com/archives/G01PW9YGZD2/p1646042397493249)

---

### Key features

1. Prevents app crashing when adding a dimension to filter/column via the chip menu

---

### Description

This issue was only relevant to dimensions originating from the DB, so only "program" and "your" dimensions. 

---