### PR TITLE
fix: add button for opening Sharing dialog for interpretation

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-02-24T10:56:43.943Z\n"
-"PO-Revision-Date: 2022-02-24T10:56:43.943Z\n"
+"POT-Creation-Date: 2022-02-28T07:46:52.105Z\n"
+"PO-Revision-Date: 2022-02-28T07:46:52.105Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -249,6 +249,9 @@ msgstr "Reply"
 
 msgid "See interpretation"
 msgstr "See interpretation"
+
+msgid "Manage sharing"
+msgstr "Manage sharing"
 
 msgid "Could not update interpretation"
 msgstr "Could not update interpretation"
@@ -657,6 +660,9 @@ msgstr "User sub-units"
 
 msgid "User sub-x2-units"
 msgstr "User sub-x2-units"
+
+msgid "This month"
+msgstr "This month"
 
 msgid "Table title"
 msgstr "Table title"

--- a/src/components/Interpretations/common/Interpretation/InterpretationSharingLink.js
+++ b/src/components/Interpretations/common/Interpretation/InterpretationSharingLink.js
@@ -1,0 +1,50 @@
+import i18n from '@dhis2/d2-i18n'
+import { SharingDialog, colors, spacers } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+
+const InterpretationSharingLink = ({ type, id }) => {
+    const [showSharingDialog, setShowSharingDialog] = useState(false)
+    return (
+        <>
+            <div className="container">
+                <span
+                    className="link"
+                    onClick={() => setShowSharingDialog(true)}
+                >
+                    {i18n.t('Manage sharing')}
+                </span>
+            </div>
+            {showSharingDialog && (
+                <SharingDialog
+                    open={true}
+                    type={type}
+                    id={id}
+                    onClose={() => setShowSharingDialog(false)}
+                />
+            )}
+            <style jsx>{`
+                .container {
+                    display: flex;
+                    align-items: center;
+                    justify-content: flex-end;
+                    gap: ${spacers.dp4};
+                    margin-top: ${spacers.dp8};
+                    font-size: 13px;
+                    color: ${colors.grey800};
+                }
+
+                .link {
+                    text-decoration: underline;
+                }
+            `}</style>
+        </>
+    )
+}
+
+InterpretationSharingLink.propTypes = {
+    id: PropTypes.string,
+    type: PropTypes.string,
+}
+
+export { InterpretationSharingLink }

--- a/src/components/Interpretations/common/Interpretation/InterpretationSharingLink.js
+++ b/src/components/Interpretations/common/Interpretation/InterpretationSharingLink.js
@@ -32,6 +32,7 @@ const InterpretationSharingLink = ({ type, id }) => {
                     margin-top: ${spacers.dp8};
                     font-size: 13px;
                     color: ${colors.grey800};
+                    cursor: pointer;
                 }
 
                 .link {

--- a/src/components/Interpretations/common/Interpretation/InterpretationUpdateForm.js
+++ b/src/components/Interpretations/common/Interpretation/InterpretationUpdateForm.js
@@ -7,6 +7,7 @@ import {
     MessageEditorContainer,
     RichTextEditor,
     MessageButtonStrip,
+    InterpretationSharingLink,
 } from '../index.js'
 
 const mutation = {
@@ -47,6 +48,7 @@ export const InterpretationUpdateForm = ({
                     disabled={loading}
                     errorText={errorText}
                 />
+                <InterpretationSharingLink id={id} type="interpretation" />
                 <MessageButtonStrip>
                     <Button
                         loading={loading}

--- a/src/components/Interpretations/common/Interpretation/index.js
+++ b/src/components/Interpretations/common/Interpretation/index.js
@@ -1,1 +1,2 @@
 export { Interpretation } from './Interpretation.js'
+export { InterpretationSharingLink } from './InterpretationSharingLink.js'


### PR DESCRIPTION
Implements [TECH-1001](https://jira.dhis2.org/browse/TECH-1001)

---

### Key features

1. allow to edit interpretations' sharing settings

---

### Description

This feature is present in the old `d2-ui` implementation.
Together with @janhenrikoverland we decided to remove the sharing access summary for now, the string can easily become too long if we should use the same format used in the About visualization panel.
Only the `Manage sharing` button is shown.

---

### Screenshots

<img width="384" alt="Screenshot 2022-02-28 at 12 08 19" src="https://user-images.githubusercontent.com/150978/155973141-9d9d29ec-38f5-408d-9c2f-25fad8378a07.png">