### PR TITLE
fix: do not show blank chips after visualization load error

### DIFF
--- a/src/components/Layout/Chip.js
+++ b/src/components/Layout/Chip.js
@@ -4,6 +4,8 @@ import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { useSelector } from 'react-redux'
+import { sGetLoadError } from '../../reducers/loader.js'
 import { ChipBase } from './ChipBase.js'
 import styles from './styles/Chip.module.css'
 import { default as TooltipContent } from './TooltipContent.js'
@@ -40,6 +42,7 @@ const Chip = ({
             dimensionType,
         },
     })
+    const globalLoadError = useSelector(sGetLoadError)
 
     let insertPosition = undefined
     if (over?.id === dimensionId) {
@@ -77,6 +80,10 @@ const Chip = ({
     const renderTooltipContent = () => (
         <TooltipContent dimensionId={dimensionId} itemIds={items} />
     )
+
+    if (globalLoadError && !dimensionName) {
+        return null
+    }
 
     return (
         <div


### PR DESCRIPTION
Implements KFMT issue, see [Slack thread](https://dhis2.slack.com/archives/G01PW9YGZD2/p1646044031725009)

---

### Key features

1. Hides the skeleton chips when there visualization has a load error

---

### Screenshots

<img width="1281" alt="Screenshot 2022-02-28 at 14 42 09" src="https://user-images.githubusercontent.com/353236/155993143-10c0c8fe-ddb8-4236-b468-73fe7ed9e238.png">

