### PR TITLE
fix: prevent clearing org unit dimension

### DIFF
--- a/src/actions/ui.js
+++ b/src/actions/ui.js
@@ -1,4 +1,7 @@
-import { DIMENSION_TYPES_PROGRAM } from '../modules/dimensionConstants.js'
+import {
+    DIMENSION_TYPES_PROGRAM,
+    DIMENSION_IDS_TIME,
+} from '../modules/dimensionConstants.js'
 import {
     getDefaulTimeDimensionsMetadata,
     getDynamicTimeDimensionsMetadata,
@@ -80,9 +83,11 @@ const tClearUiProgramRelatedDimensions =
             .concat(ui.layout.filters)
             .filter((dimensionId) => {
                 const dimension = metadata[dimensionId]
+
                 return (
                     DIMENSION_TYPES_PROGRAM.has(dimension.dimensionType) ||
-                    !enabledTimeDimensionsIds.has(dimension.id)
+                    (DIMENSION_IDS_TIME.has(dimension.id) &&
+                        !enabledTimeDimensionsIds.has(dimension.id))
                 )
             })
         dispatch(acRemoveUiLayoutDimensions(idsToRemove))


### PR DESCRIPTION
Implements KFMT issue, see [Slack thread](https://dhis2.slack.com/archives/G01PW9YGZD2/p1646055456402139?thread_ts=1646055281.685329&cid=G01PW9YGZD2) and [TECH-1006](https://jira.dhis2.org/browse/TECH-1006)

---

### Description

The problem was more widespread than just the OU dimension being cleared. There was a flaw in my logic, because I was previously adding all the dimension which were a program dimension, or not in the list of enabled time dimensions to `idsToRemove`. But when doing so, I obviously forgot to check if that ID I was about to add to `idsToRemove` was indeed a period dimension 🤦 .

---
