### PR TITLE
fix: URLs used for download

### DIFF
--- a/src/components/DownloadMenu/useDownloadMenu.js
+++ b/src/components/DownloadMenu/useDownloadMenu.js
@@ -4,6 +4,10 @@ import { useRef, useState, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import { sGetCurrent } from '../../reducers/current.js'
 import {
+    getAnalyticsEndpoint,
+    getAdaptedVisualization,
+} from '../Visualization/useAnalyticsData.js'
+import {
     DOWNLOAD_TYPE_PLAIN,
     ID_SCHEME_NAME,
     DOWNLOAD_TYPE_TABLE,
@@ -28,13 +32,16 @@ const useDownloadMenu = (relativePeriodDate) => {
             let req = new analyticsEngine.request()
             let target = '_top'
 
+            const { adaptedVisualization, parameters } =
+                getAdaptedVisualization(current)
+            const path = `${getAnalyticsEndpoint(current.outputType)}/query`
+
             switch (type) {
                 case DOWNLOAD_TYPE_TABLE:
                     req = req
-                        .fromVisualization(current)
+                        .fromVisualization(adaptedVisualization)
                         .withProgram(current.program.id)
-                        .withStage(current.programStage.id) // XXX might not always be present?
-                        .withPath('events/query') // TODO depends on event/enrollment
+                        .withPath(path)
                         .withFormat(format)
                         .withTableLayout()
                         .withColumns(
@@ -50,6 +57,7 @@ const useDownloadMenu = (relativePeriodDate) => {
                                 .join(';')
                         )
                         .withParameters({
+                            ...parameters,
                             dataIdScheme: ID_SCHEME_NAME,
                             paging: false,
                         }) // only for LL
@@ -69,12 +77,12 @@ const useDownloadMenu = (relativePeriodDate) => {
                 case DOWNLOAD_TYPE_PLAIN:
                     req = req
                         // Perhaps the 2nd arg `passFilterAsDimension` should be false for the advanced submenu?
-                        .fromVisualization(current, true)
+                        .fromVisualization(adaptedVisualization, true)
                         .withProgram(current.program.id)
-                        .withStage(current.programStage.id) // XXX might not always be present?
-                        .withPath('events/query') // TODO depends on event/enrollment
+                        .withPath(path)
                         .withFormat(format)
                         .withOutputIdScheme(idScheme)
+                        .withParameters(parameters)
 
                     // TODO options
                     // startDate

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -57,6 +57,8 @@ const formatRowValue = (rowValue, header, metaDataItems) => {
 
 const isTimeDimension = (dimensionId) => DIMENSION_IDS_TIME.has(dimensionId)
 
+const getAnalyticsEndpoint = (outputType) => analyticsApiEndpointMap[outputType]
+
 const getAdaptedVisualization = (visualization) => {
     const parameters = {}
 
@@ -154,8 +156,7 @@ const fetchAnalyticsData = async ({
         }
     }
 
-    const analyticsApiEndpoint =
-        analyticsApiEndpointMap[visualization.outputType]
+    const analyticsApiEndpoint = getAnalyticsEndpoint(visualization.outputType)
 
     // for 2.38 only /query is used (since only Line List is enabled)
     const rawResponse = await analyticsEngine[analyticsApiEndpoint].getQuery(
@@ -303,4 +304,4 @@ const useAnalyticsData = ({
     }
 }
 
-export { useAnalyticsData }
+export { useAnalyticsData, getAnalyticsEndpoint, getAdaptedVisualization }

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -72,9 +72,11 @@ const getAdaptedVisualization = (visualization) => {
                 dimensionId === DIMENSION_ID_EVENT_STATUS ||
                 dimensionId === DIMENSION_ID_PROGRAM_STATUS
             ) {
-                parameters[dimensionId] = dimensionObj.items?.map(
-                    (item) => item.id
-                )
+                if (dimensionObj.items?.length) {
+                    parameters[dimensionId] = dimensionObj.items?.map(
+                        (item) => item.id
+                    )
+                }
             } else if (!excludedDimensions.includes(dimensionId)) {
                 adaptedDimensions.push(dimensionObj)
             }


### PR DESCRIPTION
Implements [TECH-1000](https://jira.dhis2.org/browse/TECH-1000)

---

### Key features

1. fix URLs used for download
2. don't pass query parameter with `undefined` value

---

### Description

URLs used for download also use the analytics endpoint and need to pass the dimensions and time dimensions in the same fashion as the main analytics request for data.

For some parameter like `eventStatus` and `programStatus` there could be an empty item selection.
In that case, the parameter should not be added to the query string, otherwise it causes errors due to their value being `undefined`.

Example:
<img width="431" alt="Screenshot 2022-03-01 at 10 50 07" src="https://user-images.githubusercontent.com/150978/156146695-08109800-2c9f-4598-abde-8504cc77456e.png">
<img width="758" alt="Screenshot 2022-03-01 at 10 49 13" src="https://user-images.githubusercontent.com/150978/156146713-3e77b5b0-d24a-45a9-ba03-3404c5341a10.png">

