### PR TITLE
fix: set customized ui-only dimensionType for eventStatus, programStatus, createdBy, lastUpdatedBy

### DIFF
--- a/src/actions/visualization.js
+++ b/src/actions/visualization.js
@@ -1,3 +1,4 @@
+import { getDimensionType } from '../modules/dimensionConstants.js'
 import {
     SET_VISUALIZATION,
     CLEAR_VISUALIZATION,
@@ -21,7 +22,10 @@ export const acSetVisualization = (value) => {
                 [id]: {
                     valueType: dim.valueType,
                     optionSet: dim.optionSet?.id,
-                    dimensionType: dim.dimensionType,
+                    dimensionType: getDimensionType({
+                        dimensionId: id,
+                        dimensionType: dim.dimensionType,
+                    }),
                     id,
                 },
             }

--- a/src/actions/visualization.js
+++ b/src/actions/visualization.js
@@ -1,4 +1,4 @@
-import { getDimensionType } from '../modules/dimensionConstants.js'
+import { getUiDimensionType } from '../modules/dimensionConstants.js'
 import {
     SET_VISUALIZATION,
     CLEAR_VISUALIZATION,
@@ -22,7 +22,7 @@ export const acSetVisualization = (value) => {
                 [id]: {
                     valueType: dim.valueType,
                     optionSet: dim.optionSet?.id,
-                    dimensionType: getDimensionType({
+                    dimensionType: getUiDimensionType({
                         dimensionId: id,
                         dimensionType: dim.dimensionType,
                     }),

--- a/src/modules/dimensionConstants.js
+++ b/src/modules/dimensionConstants.js
@@ -28,7 +28,7 @@ export const DIMENSION_TYPES_YOURS = new Set([
 /**MAIN**/
 export const DIMENSION_TYPE_OU = 'ORGANISATION_UNIT'
 export const DIMENSION_TYPE_STATUS = 'STATUS'
-export const DIMENSION_TYPE_USER = 'DATA_X'
+export const DIMENSION_TYPE_USER = 'USER'
 
 /**PERIOD - time dimension group name**/
 export const DIMENSION_TYPE_PERIOD = 'PERIOD'
@@ -54,3 +54,18 @@ export const DIMENSION_IDS_TIME = new Set([
     DIMENSION_ID_SCHEDULED_DATE,
     DIMENSION_ID_LAST_UPDATED,
 ])
+
+export const getDimensionType = ({ dimensionId, dimensionType }) => {
+    switch (dimensionId) {
+        case DIMENSION_ID_PROGRAM_STATUS:
+        case DIMENSION_ID_EVENT_STATUS:
+            return DIMENSION_TYPE_STATUS
+
+        case DIMENSION_ID_CREATED_BY:
+        case DIMENSION_ID_LAST_UPDATED_BY:
+            return DIMENSION_TYPE_USER
+
+        default:
+            return dimensionType
+    }
+}

--- a/src/modules/dimensionConstants.js
+++ b/src/modules/dimensionConstants.js
@@ -55,7 +55,7 @@ export const DIMENSION_IDS_TIME = new Set([
     DIMENSION_ID_LAST_UPDATED,
 ])
 
-export const getDimensionType = ({ dimensionId, dimensionType }) => {
+export const getUiDimensionType = ({ dimensionId, dimensionType }) => {
     switch (dimensionId) {
         case DIMENSION_ID_PROGRAM_STATUS:
         case DIMENSION_ID_EVENT_STATUS:


### PR DESCRIPTION
Fixes an unreported bug where saving an AO with eventStatus then reopening, the wrong dialog is opened when clicking to edit the dimension.

eventStatus, programStatus, createdBy and lastUpdatedBy all have dimensionType 'DATA_X' from the backend. But the frontend needs to differentiate between "status" types and "user" types for opening the correct dialog, and showing the correct icon.

This PR sets the dimensionType relevant for ui. This does not affect saving the AO, as the dimensionTypes are not copied into current when updating. (setCurrentFromUi)

https://user-images.githubusercontent.com/6113918/156143971-ba13c4de-86a6-487b-abfb-bba7ede6ab7f.mov

)