### PR TITLE
fix: address interpretation modal regressions

### DIFF
--- a/src/components/DetailsPanel/DetailsPanel.js
+++ b/src/components/DetailsPanel/DetailsPanel.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import history from '../../modules/history.js'
 import { sGetCurrent } from '../../reducers/current.js'
+import { sGetLoadError } from '../../reducers/loader.js'
 import { sGetUser } from '../../reducers/user.js'
 import { InterpretationsUnit } from '../Interpretations/InterpretationsUnit/index.js'
 import classes from './styles/DetailsPanel.module.css'
@@ -23,33 +24,39 @@ const DetailsPanel = ({
     currentUser,
     interpretationsUnitRef,
     visualization,
-}) => (
-    <div className={classes.panel}>
-        <AboutAOUnit type="eventVisualizations" id={visualization.id} />
-        <InterpretationsUnit
-            ref={interpretationsUnitRef}
-            type="eventVisualization"
-            id={visualization.id}
-            currentUser={currentUser}
-            onInterpretationClick={(interpretationId) =>
-                navigateToOpenModal(interpretationId)
-            }
-            onReplyIconClick={(interpretationId) =>
-                navigateToOpenModal(interpretationId, true)
-            }
-        />
-    </div>
-)
+    disabled,
+}) => {
+    return (
+        <div className={classes.panel}>
+            <AboutAOUnit type="eventVisualizations" id={visualization.id} />
+            <InterpretationsUnit
+                ref={interpretationsUnitRef}
+                type="eventVisualization"
+                id={visualization.id}
+                currentUser={currentUser}
+                onInterpretationClick={(interpretationId) =>
+                    navigateToOpenModal(interpretationId)
+                }
+                onReplyIconClick={(interpretationId) =>
+                    navigateToOpenModal(interpretationId, true)
+                }
+                disabled={disabled}
+            />
+        </div>
+    )
+}
 
 DetailsPanel.propTypes = {
     currentUser: PropTypes.object.isRequired,
     interpretationsUnitRef: PropTypes.object.isRequired,
     visualization: PropTypes.object.isRequired,
+    disabled: PropTypes.bool,
 }
 
 const mapStateToProps = (state) => ({
     currentUser: sGetUser(state),
     visualization: sGetCurrent(state),
+    disabled: !!sGetLoadError(state),
 })
 
 export default connect(mapStateToProps)(DetailsPanel)

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -173,16 +173,15 @@ const InterpretationModal = ({
                 <style jsx>{`
                     .title {
                         color: ${colors.grey900};
-                        font-size: 20px;
-                        font-weight: 500;
-                        line-height: 24px;
                         margin: 0px;
-                        padding: ${spacers.dp24} ${spacers.dp24} 0;
+                        padding: ${spacers.dp24} ${spacers.dp24} ${spacers.dp4};
                     }
 
                     .ellipsis {
                         display: inline-block;
-                        line-height: 20px;
+                        font-size: 20px;
+                        font-weight: 500;
+                        line-height: 24px;
                         white-space: nowrap;
                         width: 100%;
                         overflow: hidden;

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -18,6 +18,7 @@ import React, { useEffect, useState } from 'react'
 import css from 'styled-jsx/css'
 import { Visualization } from '../../Visualization/Visualization.js'
 import { InterpretationThread } from './InterpretationThread.js'
+import { useModalContentWidth } from './useModalContentWidth.js'
 
 const modalCSS = css.resolve`
     aside {
@@ -32,6 +33,14 @@ const modalCSS = css.resolve`
         display: none;
     }
 `
+
+function getModalContentCSS(width) {
+    return css.resolve`
+        div {
+            width: ${width}px;
+        }
+    `
+}
 
 const query = {
     interpretation: {
@@ -63,6 +72,8 @@ const InterpretationModal = ({
     interpretationId,
     initialFocus,
 }) => {
+    const modalContentWidth = useModalContentWidth()
+    const modalContentCSS = getModalContentCSS(modalContentWidth)
     const [isDirty, setIsDirty] = useState(false)
     const { data, error, loading, fetching, refetch } = useDataQuery(query, {
         lazy: true,
@@ -121,7 +132,7 @@ const InterpretationModal = ({
                         )}
                     </span>
                 </h1>
-                <ModalContent className="modalContent">
+                <ModalContent className={modalContentCSS.className}>
                     <div className="container">
                         {error && (
                             <NoticeBox
@@ -170,6 +181,7 @@ const InterpretationModal = ({
                     </Button>
                 </ModalActions>
                 {modalCSS.styles}
+                {modalContentCSS.styles}
                 <style jsx>{`
                     .title {
                         color: ${colors.grey900};

--- a/src/components/Interpretations/InterpretationModal/useModalContentWidth.js
+++ b/src/components/Interpretations/InterpretationModal/useModalContentWidth.js
@@ -1,0 +1,34 @@
+import { useState, useEffect } from 'react'
+import { useDebounce } from '../../../modules/utils.js'
+
+const MODAL_SIDE_PADDING = 2 * 24
+const MODAL_SIDE_MARGINS = 2 * 128
+
+const computeModalContentWidth = (windowWidth) => {
+    return windowWidth - MODAL_SIDE_MARGINS - MODAL_SIDE_PADDING
+}
+
+export const useModalContentWidth = () => {
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+    const debouncedWindowWidth = useDebounce(windowWidth, 150)
+    const [modalContentWidth, setModalContentWidth] = useState(
+        computeModalContentWidth(windowWidth)
+    )
+
+    useEffect(() => {
+        const onResize = () => {
+            setWindowWidth(window.innerWidth)
+        }
+        window.addEventListener('resize', onResize)
+
+        return () => {
+            window.removeEventListener('resize', onResize)
+        }
+    }, [])
+
+    useEffect(() => {
+        setModalContentWidth(computeModalContentWidth(debouncedWindowWidth))
+    }, [debouncedWindowWidth])
+
+    return modalContentWidth
+}

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationForm.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationForm.js
@@ -9,7 +9,13 @@ import {
     MessageButtonStrip,
 } from '../common/index.js'
 
-export const InterpretationForm = ({ type, id, currentUser, onSave }) => {
+export const InterpretationForm = ({
+    type,
+    id,
+    currentUser,
+    disabled,
+    onSave,
+}) => {
     const [showRichTextEditor, setShowRichTextEditor] = useState(false)
     const [interpretationText, setInterpretationText] = useState('')
 
@@ -69,6 +75,7 @@ export const InterpretationForm = ({ type, id, currentUser, onSave }) => {
                 <Input
                     onFocus={() => setShowRichTextEditor(true)}
                     placeholder={inputPlaceholder}
+                    disabled={disabled}
                 />
             )}
         </MessageEditorContainer>
@@ -77,6 +84,7 @@ export const InterpretationForm = ({ type, id, currentUser, onSave }) => {
 
 InterpretationForm.propTypes = {
     currentUser: PropTypes.object,
+    disabled: PropTypes.bool,
     id: PropTypes.string,
     type: PropTypes.string,
     onSave: PropTypes.func,

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
@@ -23,6 +23,7 @@ export const InterpretationList = ({
     onInterpretationClick,
     onReplyIconClick,
     refresh,
+    disabled,
 }) => {
     const interpretationsByDate = interpretations.reduce(
         (groupedInterpretations, interpretation) => {
@@ -64,6 +65,7 @@ export const InterpretationList = ({
                                         onReplyIconClick={onReplyIconClick}
                                         onDeleted={refresh}
                                         onUpdated={refresh}
+                                        disabled={disabled}
                                     />
                                 ))}
                         </ol>
@@ -113,4 +115,5 @@ InterpretationList.propTypes = {
     refresh: PropTypes.func.isRequired,
     onInterpretationClick: PropTypes.func.isRequired,
     onReplyIconClick: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
 }

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -39,7 +39,14 @@ const interpretationsQuery = {
 
 export const InterpretationsUnit = forwardRef(
     (
-        { currentUser, type, id, onInterpretationClick, onReplyIconClick },
+        {
+            currentUser,
+            type,
+            id,
+            onInterpretationClick,
+            onReplyIconClick,
+            disabled,
+        },
         ref
     ) => {
         const [isExpanded, setIsExpanded] = useState(true)
@@ -106,12 +113,14 @@ export const InterpretationsUnit = forwardRef(
                                     }
                                     onReplyIconClick={onReplyIconClick}
                                     refresh={onCompleteAction}
+                                    disabled={disabled}
                                 />
                                 <InterpretationForm
                                     currentUser={currentUser}
                                     type={type}
                                     id={id}
                                     onSave={onCompleteAction}
+                                    disabled={disabled}
                                 />
                             </>
                         )}
@@ -195,6 +204,7 @@ InterpretationsUnit.propTypes = {
     currentUser: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
     onInterpretationClick: PropTypes.func,
     onReplyIconClick: PropTypes.func,
 }

--- a/src/components/Interpretations/common/Interpretation/Interpretation.js
+++ b/src/components/Interpretations/common/Interpretation/Interpretation.js
@@ -13,6 +13,7 @@ export const Interpretation = ({
     onClick,
     onUpdated,
     onDeleted,
+    disabled,
     onReplyIconClick,
 }) => {
     const [isUpdateMode, setIsUpdateMode] = useState(false)
@@ -21,6 +22,7 @@ export const Interpretation = ({
         currentUser,
         onComplete: onUpdated,
     })
+    const shouldShowButton = !!onClick && !disabled
 
     return isUpdateMode ? (
         <InterpretationUpdateForm
@@ -36,40 +38,44 @@ export const Interpretation = ({
             created={interpretation.created}
             id={interpretation.id}
             username={interpretation.user.displayName}
-            onClick={onClick}
+            onClick={disabled ? undefined : onClick}
         >
-            <MessageStatsBar>
-                <MessageIconButton
-                    tooltipContent={
-                        isLikedByCurrentUser ? i18n.t('Unlike') : i18n.t('Like')
-                    }
-                    iconComponent={IconThumbUp16}
-                    onClick={toggleLike}
-                    selected={isLikedByCurrentUser}
-                    count={interpretation.likes}
-                    disabled={toggleLikeInProgress}
-                />
-                <MessageIconButton
-                    tooltipContent={i18n.t('Reply')}
-                    iconComponent={IconReply16}
-                    onClick={() => onReplyIconClick(interpretation.id)}
-                    count={interpretation.comments.length}
-                />
-                {interpretation.access.update && (
+            {!disabled && (
+                <MessageStatsBar>
                     <MessageIconButton
-                        iconComponent={IconEdit16}
-                        tooltipContent={i18n.t('Edit')}
-                        onClick={() => setIsUpdateMode(true)}
+                        tooltipContent={
+                            isLikedByCurrentUser
+                                ? i18n.t('Unlike')
+                                : i18n.t('Like')
+                        }
+                        iconComponent={IconThumbUp16}
+                        onClick={toggleLike}
+                        selected={isLikedByCurrentUser}
+                        count={interpretation.likes}
+                        disabled={toggleLikeInProgress}
                     />
-                )}
-                {interpretation.access.delete && (
-                    <InterpretationDeleteButton
-                        id={interpretation.id}
-                        onComplete={onDeleted}
+                    <MessageIconButton
+                        tooltipContent={i18n.t('Reply')}
+                        iconComponent={IconReply16}
+                        onClick={() => onReplyIconClick(interpretation.id)}
+                        count={interpretation.comments.length}
                     />
-                )}
-            </MessageStatsBar>
-            {!!onClick && (
+                    {interpretation.access.update && (
+                        <MessageIconButton
+                            iconComponent={IconEdit16}
+                            tooltipContent={i18n.t('Edit')}
+                            onClick={() => setIsUpdateMode(true)}
+                        />
+                    )}
+                    {interpretation.access.delete && (
+                        <InterpretationDeleteButton
+                            id={interpretation.id}
+                            onComplete={onDeleted}
+                        />
+                    )}
+                </MessageStatsBar>
+            )}
+            {shouldShowButton && (
                 <Button
                     secondary
                     small
@@ -91,5 +97,6 @@ Interpretation.propTypes = {
     onDeleted: PropTypes.func.isRequired,
     onReplyIconClick: PropTypes.func.isRequired,
     onUpdated: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
     onClick: PropTypes.func,
 }

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -63,7 +63,9 @@ export const Visualization = ({
 }) => {
     const dispatch = useDispatch()
     const metadata = useSelector(sGetMetadata)
-    const { availableOuterWidth, availableInnerWidth } = useAvailableWidth()
+    const isInModal = !!relativePeriodDate
+    const { availableOuterWidth, availableInnerWidth } =
+        useAvailableWidth(isInModal)
     const defaultSortField = visualization[AXIS_ID_COLUMNS][0].dimension
     const defaultSortDirection = 'asc'
 

--- a/src/components/Visualization/useAvailableWidth.js
+++ b/src/components/Visualization/useAvailableWidth.js
@@ -6,10 +6,15 @@ import {
     sGetUiShowAccessoryPanel,
 } from '../../reducers/ui.js'
 
-const LEFT_SIDEBARS_WIDTH = 260
-const RIGHT_SIDEBAR_WIDTH = 380
-const PADDING = 2 * 4
-const BORDER = 2 * 1
+const PAGE_LEFT_SIDEBARS_WIDTH = 260
+const PAGE_RIGHT_SIDEBAR_WIDTH = 380
+const PAGE_PADDING = 2 * 4
+const PAGE_BORDER = 2 * 1
+
+const MODAL_SIDEBAR_WIDTH = 300
+const MODAL_GAP = 16
+const MODAL_SIDE_PADDING = 2 * 24
+const MODAL_SIDE_MARGINS = 2 * 128
 
 const className = '__scrollbar-width-test__'
 const styles = `
@@ -40,28 +45,50 @@ const scrollbarWidth = (() => {
     return width
 })()
 
-const computeAvailableOuterWidth = (windowWidth, leftOpen, rightOpen) => {
+const computeOuterWidthInModal = ({ windowWidth }) =>
+    windowWidth -
+    MODAL_SIDEBAR_WIDTH -
+    MODAL_GAP -
+    MODAL_SIDE_PADDING -
+    MODAL_SIDE_MARGINS
+
+const computeOuterWidthInPage = ({ windowWidth, leftOpen, rightOpen }) => {
     let availableOuterWidth =
-        windowWidth - LEFT_SIDEBARS_WIDTH - PADDING - BORDER
+        windowWidth - PAGE_LEFT_SIDEBARS_WIDTH - PAGE_PADDING - PAGE_BORDER
 
     if (leftOpen) {
-        availableOuterWidth -= LEFT_SIDEBARS_WIDTH
+        availableOuterWidth -= PAGE_LEFT_SIDEBARS_WIDTH
     }
 
     if (rightOpen) {
-        availableOuterWidth -= RIGHT_SIDEBAR_WIDTH
+        availableOuterWidth -= PAGE_RIGHT_SIDEBAR_WIDTH
     }
 
     return availableOuterWidth
 }
 
-export const useAvailableWidth = () => {
+const computeAvailableOuterWidth = ({
+    isInModal,
+    windowWidth,
+    leftOpen,
+    rightOpen,
+}) =>
+    isInModal
+        ? computeOuterWidthInModal({ windowWidth })
+        : computeOuterWidthInPage({ windowWidth, leftOpen, rightOpen })
+
+export const useAvailableWidth = (isInModal) => {
     const [windowWidth, setWindowWidth] = useState(window.innerWidth)
     const debouncedWindowWidth = useDebounce(windowWidth, 150)
     const leftOpen = useSelector(sGetUiShowAccessoryPanel)
     const rightOpen = useSelector(sGetUiShowDetailsPanel)
     const [availableOuterWidth, setAvailableOuterWidth] = useState(
-        computeAvailableOuterWidth(windowWidth, leftOpen, rightOpen)
+        computeAvailableOuterWidth({
+            isInModal,
+            windowWidth,
+            leftOpen,
+            rightOpen,
+        })
     )
 
     useEffect(() => {
@@ -77,16 +104,17 @@ export const useAvailableWidth = () => {
 
     useEffect(() => {
         setAvailableOuterWidth(
-            computeAvailableOuterWidth(
-                debouncedWindowWidth,
+            computeAvailableOuterWidth({
+                isInModal,
+                windowWidth: debouncedWindowWidth,
                 leftOpen,
-                rightOpen
-            )
+                rightOpen,
+            })
         )
-    }, [leftOpen, rightOpen, debouncedWindowWidth])
+    }, [isInModal, leftOpen, rightOpen, debouncedWindowWidth])
 
     return {
         availableOuterWidth,
-        availableInnerWidth: availableOuterWidth - scrollbarWidth - BORDER,
+        availableInnerWidth: availableOuterWidth - scrollbarWidth - PAGE_BORDER,
     }
 }


### PR DESCRIPTION
Implements [TECH-1005](https://jira.dhis2.org/browse/TECH-1005)
_And some other issues with the interpretations modal_

---

### Key features

1. Adds whitespace below the title and prevent the characters from being clipped
2. Implement calculated widths for both the modal content and the visualization, to prevent a horizontal scrollbar from appearing
3. Disable interpretation thread when there is a visualization load error

---

### Known issues

-  Both the modal content and the visulaization are using a computed width based on the window width. The `InterpretationsModal` component is going to go into analytics, and the `Visualization` component is staying in the app, or will be a separate analytics component. As such, I didn't see much opportunity for code-sharing right now, so I have a bit of duplicated logic.

---

### Screenshots

*Disabled on load error*
<img width="904" alt="Screenshot 2022-03-01 at 10 54 29" src="https://user-images.githubusercontent.com/353236/156146867-d9ab6546-85e1-4126-bc95-c6e9d011c3bd.png">
