### PR TITLE
fix: format event/enrollment/incident dates (TECH-1008)

### DIFF
--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -11,6 +11,7 @@ import {
     Pagination,
 } from '@dhis2/ui'
 import cx from 'classnames'
+import moment from 'moment'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
@@ -18,6 +19,9 @@ import { acSetLoadError } from '../../actions/loader.js'
 import {
     DIMENSION_ID_EVENT_STATUS,
     DIMENSION_ID_PROGRAM_STATUS,
+    DIMENSION_ID_EVENT_DATE,
+    DIMENSION_ID_ENROLLMENT_DATE,
+    DIMENSION_ID_INCIDENT_DATE,
 } from '../../modules/dimensionConstants.js'
 import { genericServerError, noPeriodError } from '../../modules/error.js'
 import {
@@ -128,6 +132,16 @@ export const Visualization = ({
             ].includes(header?.name)
         ) {
             return metadata[value]?.name || value
+        } else if (
+            [
+                DIMENSION_ID_EVENT_DATE,
+                DIMENSION_ID_ENROLLMENT_DATE,
+                DIMENSION_ID_INCIDENT_DATE,
+            ]
+                .map((header) => headersMap[header])
+                .includes(header?.name)
+        ) {
+            return moment(value).format('L')
         } else {
             return formatValue(value, header?.valueType || 'TEXT', {
                 digitGroupSeparator: visualization.digitGroupSeparator,

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -141,7 +141,7 @@ export const Visualization = ({
                 .map((header) => headersMap[header])
                 .includes(header?.name)
         ) {
-            return moment(value).format('L')
+            return moment(value).format('yyyy-MM-DD')
         } else {
             return formatValue(value, header?.valueType || 'TEXT', {
                 digitGroupSeparator: visualization.digitGroupSeparator,


### PR DESCRIPTION
Implements [TECH-1008](https://jira.dhis2.org/browse/TECH-1008)


---

### Key features

1. format event/enrollment/incident dates

---

### Description

Remove the timestamp and format according to the instance locale and
date format preferences.

---

### Screenshots

Before:
<img width="163" alt="Screenshot 2022-03-01 at 11 15 39" src="https://user-images.githubusercontent.com/150978/156150893-71c87e75-68e1-455e-a89b-e3c2c23c9820.png">

After:
<img width="137" alt="Screenshot 2022-03-01 at 12 06 09" src="https://user-images.githubusercontent.com/150978/156158193-ca668694-e97f-4a34-a409-bd29d416896f.png">

