### PR TITLE
fix: remove debug text from conditions dialog

### DIFF
--- a/src/components/Dialogs/Conditions/ConditionsManager.js
+++ b/src/components/Dialogs/Conditions/ConditionsManager.js
@@ -366,16 +366,6 @@ const ConditionsManager = ({
     const renderConditions = () => (
         <>
             <div>
-                <small>
-                    <p>
-                        valueType: <b>{valueType}</b>, dimensionType:
-                        <b> {dimension.dimensionType}</b>, id:
-                        <b> {dimension.id}</b>
-                    </p>
-                    {
-                        // FIXME: For testing only
-                    }
-                </small>
                 {isSupported ? (
                     <p className={commonClasses.paragraph}>
                         {i18n.t(


### PR DESCRIPTION
### Key features

1. remove debug text in conditions dialog

---

### Screenshots

Before:
<img width="807" alt="Screenshot 2022-03-01 at 12 16 50" src="https://user-images.githubusercontent.com/150978/156159640-f3c56520-0948-49d2-8ae7-da388884fb56.png">

After:
<img width="817" alt="Screenshot 2022-03-01 at 12 16 31" src="https://user-images.githubusercontent.com/150978/156159600-b35f609c-4921-45c1-ad6b-e063ed665028.png">

