### PR TITLE
fix: set optionSet so the correct modal is opened

### DIFF
--- a/src/components/DndContext.js
+++ b/src/components/DndContext.js
@@ -260,6 +260,7 @@ const OuterDndContext = ({ children }) => {
                     name: active.data.current.name,
                     dimensionType: active.data.current.dimensionType,
                     valueType: active.data.current.valueType,
+                    optionSet: active.data.current.optionSet,
                 },
             })
         )


### PR DESCRIPTION
The optionSet value is needed in order to open the correct modal. When dragging a dimension item into the layout, this value was missing.