### PR TITLE
fix: chip not showing the selected condition

### DIFF
--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -79,7 +79,9 @@ const getConditionsFromVisualization = (vis) =>
         .reduce(
             (acc, key) => ({
                 ...acc,
-                [key.dimension]: {
+                [key.programStage?.id
+                    ? `${key.programStage.id}.${key.dimension}`
+                    : key.dimension]: {
                     condition: key.filter,
                     legendSet: key.legendSet?.id,
                 },


### PR DESCRIPTION

### Key features

1. fix chip dialog to correctly show the condition

---

### Description

The unprefixed ids caused the chip to not show the selected condition correctly.
This only happened if the dimension has a program stage set.
Before the id used as key in `conditions` was not prefixed with the program stage id, causing the lookup from the chip to fail.

---

### Screenshots

Before:
<img width="840" alt="Screenshot 2022-03-02 at 10 14 40" src="https://user-images.githubusercontent.com/150978/156331672-12bfe33b-38cb-4330-99eb-6700f7a0e901.png">
<img width="379" alt="Screenshot 2022-03-02 at 10 15 18" src="https://user-images.githubusercontent.com/150978/156331689-f9428744-e74f-42fe-b934-64f77e46a9b5.png">

After:
<img width="837" alt="Screenshot 2022-03-02 at 10 14 27" src="https://user-images.githubusercontent.com/150978/156331730-0d647815-68de-4166-8f5e-70e864f1d7bb.png">
<img width="432" alt="Screenshot 2022-03-02 at 10 14 19" src="https://user-images.githubusercontent.com/150978/156331745-26be8cb8-32d2-4681-91b8-2bcddf4a2ca4.png">

