### PR TITLE
fix: use visualization without total in pager

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-02T07:39:09.900Z\n"
-"PO-Revision-Date: 2022-03-02T07:39:09.900Z\n"
+"POT-Creation-Date: 2022-03-02T15:35:22.490Z\n"
+"PO-Revision-Date: 2022-03-02T15:35:22.490Z\n"
 
 msgid "Add to {{axisName}}"
 msgstr "Add to {{axisName}}"
@@ -649,11 +649,11 @@ msgstr "Something went wrong"
 msgid "Organisation unit"
 msgstr "Organisation unit"
 
-msgid "Program status"
-msgstr "Program status"
-
 msgid "Event status"
 msgstr "Event status"
+
+msgid "Program status"
+msgstr "Program status"
 
 msgid "Created by"
 msgstr "Created by"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@dhis2/analytics": "^23.6.0",
         "@dhis2/app-runtime": "^3.2.8",
         "@dhis2/d2-ui-rich-text": "^7.3.3",
-        "@dhis2/ui": "^8.0.0",
+        "@dhis2/ui": "^8.1.0",
         "@dnd-kit/core": "^5.0.1",
         "@dnd-kit/sortable": "^6.0.0",
         "@dnd-kit/utilities": "^3.1.0",
@@ -60,7 +60,7 @@
     },
     "resolutions": {
         "@dhis2/prop-types": "^1.6.4",
-        "@dhis2/ui": "^8.0.0",
+        "@dhis2/ui": "^8.1.0",
         "i18next": "^20.5.0"
     }
 }

--- a/src/components/Visualization/Visualization.js
+++ b/src/components/Visualization/Visualization.js
@@ -279,32 +279,25 @@ export const Visualization = ({
                                 >
                                     <Pagination
                                         page={page}
-                                        pageCount={data.pageCount}
                                         pageSize={pageSize}
-                                        total={data.total}
+                                        isLastPage={data.isLastPage}
                                         onPageChange={setPage}
                                         onPageSizeChange={setPageSize}
                                         pageSizeSelectText={i18n.t(
-                                            'Cases per page'
+                                            'Rows per page'
                                         )}
+                                        pageLength={data.rows.length}
                                         pageSummaryText={({
                                             firstItem,
                                             lastItem,
-                                            total,
+                                            page,
                                         }) =>
                                             i18n.t(
-                                                '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                                                'Page {{page}}, row {{firstItem}}-{{lastItem}}',
                                                 {
-                                                    firstCaseIndex: firstItem,
-                                                    lastCaseIndex: lastItem,
-                                                    count: total,
-                                                    // FIXME does it make sense if there is only 1 case?! "1 of 1 case"
-                                                    // not sure is possible to have empty string for singular with i18n
-                                                    // TODO also, this string for some reason is not extracted
-                                                    defaultValue:
-                                                        '{{firstCaseIndex}} of {{count}} case',
-                                                    defaultValue_plural:
-                                                        '{{firstCaseIndex}}-{{lastCaseIndex}} of {{count}} cases',
+                                                    firstItem,
+                                                    lastItem,
+                                                    page,
                                                 }
                                             )
                                         }

--- a/src/components/Visualization/useAnalyticsData.js
+++ b/src/components/Visualization/useAnalyticsData.js
@@ -131,6 +131,7 @@ const fetchAnalyticsData = async ({
         .fromVisualization(adaptedVisualization)
         .withParameters({
             headers,
+            totalPages: false,
             ...parameters,
         })
         .withProgram(visualization.program.id)
@@ -238,11 +239,10 @@ const useAnalyticsData = ({
             })
             const headers = extractHeaders(analyticsResponse)
             const rows = extractRows(analyticsResponse, headers)
-            const pageCount = analyticsResponse.metaData.pager.pageCount
-            const total = analyticsResponse.metaData.pager.total
+            const pager = analyticsResponse.metaData.pager
 
             mounted.current && setError(undefined)
-            mounted.current && setData({ headers, rows, pageCount, total })
+            mounted.current && setData({ headers, rows, ...pager })
             onResponseReceived(analyticsResponse)
         } catch (error) {
             mounted.current && setError(error)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,564 +1390,564 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@dhis2-ui/alert@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-8.0.0.tgz#c84803e0412ef0b643212af467f2ce0ea74cfa74"
-  integrity sha512-EpqsDtjQgin+2CS8MA6ghquSz0hm6Tv/a51eU6AmgE4/6D+XQQao87H4U+4nFJKjPVh/RJ9V6bXFVg0PxbCdGw==
+"@dhis2-ui/alert@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/alert/-/alert-8.1.0.tgz#f536dfcd968254611995ff3e07c3cceff6e058cd"
+  integrity sha512-SlGu0qzU1JhXBUxKhXTMbsVQeNxPYlp7i5PRLveflSWf64ABkIiWBhFUfNsmL+W07/xY+JubbfD3wxcgnyt4eQ==
   dependencies:
-    "@dhis2-ui/portal" "8.0.0"
+    "@dhis2-ui/portal" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/box@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-8.0.0.tgz#005b65807ff7beafbaf5b36e6b5d01585b3447bf"
-  integrity sha512-hVfU4zpUW9TbzpeNN5nLp7yNknRTSO6E2nRgOS6hVjapjOp/PTSbV0jlTLTRPA6esi40cuPx0A6X87NS/RS3rA==
+"@dhis2-ui/box@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/box/-/box-8.1.0.tgz#7c5110b80bbcfee57e82b9de00a5ddead943d40d"
+  integrity sha512-REseWJDfbCZu+KzCo/k/7YEfeEq8GFE/Bj88mV5YZoZoBak0HNF2nRrwG+8OnPOMu/tfslpByHCjF9/NQ9jTmg==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/button@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-8.0.0.tgz#4eed1bb242a1789d82e0d03b0354c3147579d207"
-  integrity sha512-EiaMzSMh9h9VLhuMcf1uoHMP0EG1fPaBYjAvCZsuhIzy8C3I2iSAcACX8LZ4PPDdRgAtKMQ/1ivYYkNHT5CmYA==
+"@dhis2-ui/button@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/button/-/button-8.1.0.tgz#a3623fec02cb756c7b718f3d29643c20c322e3b7"
+  integrity sha512-yr3L1TTStXPDPBxqy8ieI1VF3VM4uhQL+d9AoEryjY4Zpa1TK/hV+S3ryMnfbYgPKIlLGd2rfXmOttdKfkxmuQ==
   dependencies:
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/card@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-8.0.0.tgz#be170533f4f36dc63ab2461e1576aea9b4186d4b"
-  integrity sha512-P7jBQO2lpKdrUjIyqG2UupxofMrvsMsR2sb1WoQn5ltmK6VtLVWX9uRVsD+UYGZgVv3FsDsppeYWDtjwWB++nA==
+"@dhis2-ui/card@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/card/-/card-8.1.0.tgz#b8bba34bcb9eef2c376fd159d0cfcc7954839dcb"
+  integrity sha512-F4lylwBw8nqsaM+IvO7q3FQFrEFVDkhtXTfax4wStTfA+7UlVBL3XW2IYawjCYe6Cc2Xtr0OZHMPy6V+AG2uUg==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/center@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-8.0.0.tgz#4e4d526b180bd1bfce90bd7100271073cfc23e40"
-  integrity sha512-fb+5NIK28s7w5DHmlb+ZLC/0q0EJXnlYFtnPtbnjh+Tch6mYZ0BLte1AKdjtLt4MSDvTelwwmy25ix6BOGTybA==
+"@dhis2-ui/center@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/center/-/center-8.1.0.tgz#4d0007d0ffe6e9b15d47936e4864b56e77ed7ecf"
+  integrity sha512-qXBLLKvxb/hF+dWtowkROjUCWGXsOJZQD+zcLCvDzWonZikAIcIe1S91kV3tP5QdgtAxXrD8DwMXo6YMqsxoog==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/checkbox@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-8.0.0.tgz#3514fe37738e901227af7e32a92ea25f86078bee"
-  integrity sha512-7CKyhVpN4eOyv31yzm8YtPaNDbKg2QH4nYGySHNl8kKcpq4QfRvJsJaXtOqR9qgfcangtFwhkOnJsNfX3x4e5w==
+"@dhis2-ui/checkbox@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/checkbox/-/checkbox-8.1.0.tgz#8842a06abb3f291d00b605a97845bfc3f8dfbf51"
+  integrity sha512-5plKXiirmzY6vf2ithL4jswoWapBlO/IdbyQRkBZtaD5WnzmB6W0OdZNmsBCYtpeh3ktC0s7HESwr/+be7MT0Q==
   dependencies:
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/required" "8.0.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/required" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/chip@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-8.0.0.tgz#2202ae57df7a198df79885b913c490270cfed413"
-  integrity sha512-qfi9O34M3ie535qv8b477ly3DzmSbAmvq/vw4+JIEuoR8/IqJ6XJxgyyZWVpjPfpqWRv0fesdxLbnmtPNjHpiQ==
+"@dhis2-ui/chip@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/chip/-/chip-8.1.0.tgz#519926a38a8bfa9c68049861ece659ad413dba70"
+  integrity sha512-uDuQ+lnig+c/cq6i0iJcf149zZcSP/KvYUSEjw0gMHC76Xhhw0FdeOCDRo3dA5/F78X4kqRhP7YdoKbxYAOu5A==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/cover@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-8.0.0.tgz#5e181097bd451250c51d354bb5186577d28fc1eb"
-  integrity sha512-BnqFxc8pEqH/i+iGnkuxVPrfPoUCrf0JEZ0JoMAy66KpaA2RmDfmZ2QYzzW7cniXaMP/TllP5XV4YkS9StlzFQ==
+"@dhis2-ui/cover@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/cover/-/cover-8.1.0.tgz#dd509a5543a57bbf5370f3e708c7982d0b1b809a"
+  integrity sha512-hAsfpFf01p4bq7WaUQT6HZJJ31nMAtp2jNnwo1SwYnK2ccPwLBw6ssc1BKC+FsvlB9p8LGOmMBGanfP0czhccw==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/css@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-8.0.0.tgz#a0ba5f10459408877679f0a6b12ee4e3001b3b2e"
-  integrity sha512-G3ggfAw2YeiNU7hLiMBRMBVm3DjOFQr4W44ejP7Ji0wH6kk/4QGU8SI3ZNNbF4lOs4Vgkdsa20/vg+Xan0eEmw==
+"@dhis2-ui/css@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/css/-/css-8.1.0.tgz#f33fed637f2f02756ee36a7e0d9ede77414896c5"
+  integrity sha512-kPIQ3ONxak2T12VFCulpB2hbS5ICEbnxAv2yhhBy0Z4ZqIbZC16OVXNu0o9wXehxszaCadjJ1ra8BgaGSoB1TQ==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/divider@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-8.0.0.tgz#8fc98df436cc42d2a997ece685d879ff000a8039"
-  integrity sha512-u//XeWBDIxJ7M2OTdk+4SzpjSDUJKRRKNhBCLNoPk6FcT5Lunq4lzQ0F8GNif9S3EVXiztxHihLnFUtoXvHofA==
+"@dhis2-ui/divider@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/divider/-/divider-8.1.0.tgz#cb71b46b5646b4f89eec973b000e1525f1ba0969"
+  integrity sha512-7qLy39iKmF3EhvfR67ZY9J69Lv+XGxMraCutuA4KQr910cNEiWG5AjtbZGsWKZoQ7JJFzMR7lVnU6Axgdp47vQ==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/field@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-8.0.0.tgz#e0cf8e0e82c366de8bf40776a277149180ed9dad"
-  integrity sha512-oxDGSUtQBi856eoyB+h/TFGxeI71+SuH0h5JwHO69Xlx6PcGF0737XSqPyck16YCMFUx5ty72tUOU7cb9z4w8Q==
+"@dhis2-ui/field@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/field/-/field-8.1.0.tgz#2a57ee06c61b5778e97b89cd60b170667eeff643"
+  integrity sha512-y8mVmwELQXo2ZRnamCr29F6P8kJ5MM/iQ5dtftDleHfd5eqMqP2iNaTKl/AJuRCr9+kd5hAVPWHxcQXzwtrKDg==
   dependencies:
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/help" "8.0.0"
-    "@dhis2-ui/label" "8.0.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/help" "8.1.0"
+    "@dhis2-ui/label" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/file-input@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-8.0.0.tgz#81f2a2eb86cc04848c3e2cece77e7e1d5bfba77c"
-  integrity sha512-ge9jYhKBj8yIoSiCB3Pbfy4STw6mnNh+uVdxgE4ov5sa7RmdFrWflu7hUImQXercuB0ymp5DKHAAVvNdeOUf3w==
+"@dhis2-ui/file-input@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/file-input/-/file-input-8.1.0.tgz#d76b7936b8a737f0c87170560d6d3e6b0ff897b9"
+  integrity sha512-6T0EaPOZulZsUL7qpJBnWmMKxf9m7UA2SWpa3ODxB92KPVf+2/NbEnPzhhcpxBZ3egSyQ5zavIlw4rIfDCwoDg==
   dependencies:
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/label" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/status-icon" "8.0.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/label" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/status-icon" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/header-bar@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-8.0.0.tgz#ee07bd4b441cb63bf0669f3b50dc2e55106b01b1"
-  integrity sha512-sRTfz9Ht3yvgiFuuwRIUyahS+eHyLDjYZGy7stq4MrZunn0kAancVTF6DNkJy1mqldCk4uwsOB9VYLV/DJ6TUQ==
+"@dhis2-ui/header-bar@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/header-bar/-/header-bar-8.1.0.tgz#3bcecd53f34457faa53e945acceac4e708640f82"
+  integrity sha512-Xtg8dFnOpRp2v0xh6CUnwRxLAqRfAZOMCR0KAACqemkv+NmvDaFIkBXRr/B/68zFDhZKQ4PaXACcOL/gTtk/1w==
   dependencies:
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/center" "8.0.0"
-    "@dhis2-ui/divider" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/logo" "8.0.0"
-    "@dhis2-ui/menu" "8.0.0"
-    "@dhis2-ui/user-avatar" "8.0.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/center" "8.1.0"
+    "@dhis2-ui/divider" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/logo" "8.1.0"
+    "@dhis2-ui/menu" "8.1.0"
+    "@dhis2-ui/user-avatar" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     moment "^2.29.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/help@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-8.0.0.tgz#c56d48c49f240fceb7049fdad521698652b2f423"
-  integrity sha512-ehv05Q+c5SsfgOapRATad1M6dXyBE6HWbm5dDeoJVQlrxDefPu/MykOvXiEN3bRJPAN4McRhdxJngFiuFXZqjA==
+"@dhis2-ui/help@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/help/-/help-8.1.0.tgz#a4d57c880727421436675908739011148b4234c6"
+  integrity sha512-48oSdWO8p5b3VfJgZ7mgWhSgWvjWYQ6uishVrUsHvWW66QZOEnJThHa/mBteQJtz/bRnJUL5ddRTUqjljVbPLw==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/input@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-8.0.0.tgz#a4fcbaed04bda0ed8427692579cf7df9e3df4503"
-  integrity sha512-5LJId2EckeYlMn8SI76zdV5ttoHFZoIm7042bETrGF/HCJN/kGP1zM+3MOBNvO50xistPiALmJ87IXSNqlv3Pw==
+"@dhis2-ui/input@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/input/-/input-8.1.0.tgz#739e4b82262f2687188ba18c4bf6ba193c074a38"
+  integrity sha512-NrEZW18e89BEAKoYytQWRquUogKLFXDIPzQ5lweOCYuwjUVPH75njGG9Rcmi8mQxHRJdLHIAZVeUgitKOH+mUQ==
   dependencies:
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/status-icon" "8.0.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/status-icon" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/intersection-detector@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-8.0.0.tgz#43bc8b3605100686b9930ecd2d1e706bde5b13c3"
-  integrity sha512-H1GmSdS3gfkOjEVJhcSnpxrnZq0oaPxzB4cIc6E1lSt/a1CxAt6AiMEhIQwr9Fix6yU0tX7218r1SB36tGBtjA==
+"@dhis2-ui/intersection-detector@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/intersection-detector/-/intersection-detector-8.1.0.tgz#f4aa3539c19e8b10b583354d12ddbfe6a06fa063"
+  integrity sha512-M7meopgfozEGUGM8fbuVmz8cV/WDIIUkuPTzxRmIwdKu+G9nVfsaQE4jE1U0KnBcxo/2uEoV2iPMLwNq7fOpvg==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/label@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-8.0.0.tgz#94643677b6734206a0f03133ab07aaa4bd46a8b5"
-  integrity sha512-cPtac9hfdX6cnR5xUY5izhbTepIz7PvPFlfN4WLBkZVXw46p+3KVFwsh8HR+Ya9lyxNlL+bgUUZ7PpREcy+nsQ==
+"@dhis2-ui/label@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/label/-/label-8.1.0.tgz#780937a499ea668e5410964f74adde360ea25ee0"
+  integrity sha512-qsAtogvuuB/X60RFVmFyW61KH1mwjKqvaqlYSNISEe0aW3Q0bwsCtCbaoz4IfKwmhsiXprTcktLh6IgF66/ZeA==
   dependencies:
-    "@dhis2-ui/required" "8.0.0"
+    "@dhis2-ui/required" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/layer@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-8.0.0.tgz#83d451881bb5249eaf21d66277aaedcf923d9097"
-  integrity sha512-SKNyROOt5UDhvumvPAGNU97rOnge9v0/tjs+GfC9Q+l3gDEKB4zMKPIhjRPB0J0V2bG1YD8SzklNWjuQIkyKjg==
+"@dhis2-ui/layer@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/layer/-/layer-8.1.0.tgz#ec110ab3eb987fcecb4fc7ae545130edf8978f50"
+  integrity sha512-WqXXPlyQjY7x7J0GwhBcnxwfxEpwsHf4cXw7u/hhdXjT4D9qCErDei5NPrtD36+hFAZ1JLpbnNC9DnbnR3PLeQ==
   dependencies:
-    "@dhis2-ui/portal" "8.0.0"
+    "@dhis2-ui/portal" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/legend@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-8.0.0.tgz#fcc98df09d0bc26aa51d100a064afc43b9e038ed"
-  integrity sha512-efpt03UhVhY9VJ3grUduiDJ0HHJuMaGyQgmzK4V/HGMmZlbaOeneK7lTrlGCou/LEWEO4sGsu1KswYnBWdo5LQ==
+"@dhis2-ui/legend@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/legend/-/legend-8.1.0.tgz#a6f128b8c26bdf2afbb5748f81c2ca109da6e92e"
+  integrity sha512-Gwx+CxWadqksM1BpiWVUdgM7Xg07eP34tJmHLKHvqvrNt7ZIM6YAW1sFk7QV/3awobvOhw7PGh3Nho6hhWD3Hg==
   dependencies:
-    "@dhis2-ui/required" "8.0.0"
+    "@dhis2-ui/required" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/loader@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-8.0.0.tgz#3d36c0070ddf6a2a98e72268fb5c514298d8df18"
-  integrity sha512-8XALQhCY0l4SEX+7KA4bL9Ds9jV2Fr9OagRb/OeI1Xb9QFrwCiz3ag+7BcuJRxPloEfH/jblDmD5yfncsDer2A==
+"@dhis2-ui/loader@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/loader/-/loader-8.1.0.tgz#c7ec930870f67319b70b76d4292aac6351659417"
+  integrity sha512-nYMAdCHdhgqaXNHrmKJR7Xn3BFMYdr4Zob6PPWTmkfbRygqItx+d2uuArE3Tvf1DFv0O4DSudOEjkZ6Ne6lSVQ==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/logo@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-8.0.0.tgz#01980140010e9d0d74a323860c5d4fc52fecd644"
-  integrity sha512-L30+MC5OW/aeVaaf/mHA6hAyJ5LSaQscU2A20Y8YIIQdwe370vaPFwR6UHYY23efWVUxRsh+43ALV7wruU5Pag==
+"@dhis2-ui/logo@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/logo/-/logo-8.1.0.tgz#dadf28eda5989c0aedb73b6ea7f7a52b10ce3e42"
+  integrity sha512-Vxzi6xRVMH4tJmpItT4AAUiOvFu32OMjQbEIT1QK3lDSgFnpW2TT/eXjn3yptWDFxzycvJbMnOiR2ORX57ljpA==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/menu@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-8.0.0.tgz#dbb857419ee1c1ba1c3078e650ee033ee43e9d2a"
-  integrity sha512-Jq/nTe6R2epScOop6HI3bIEJhqY6HHwC8E8dFwemEsrYpncyDqzMhOzwBUy9A23BgLsd4BaA1YeAAfHXRGu6Mg==
+"@dhis2-ui/menu@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/menu/-/menu-8.1.0.tgz#5242b71812a7ce54ed3c7d9598dc86164dec37e4"
+  integrity sha512-jaisPYtWsvUV7GAuCWt5cyYUtYzd7yfwDEcTW5cszFle3SwHNdclXZRMkBwinA+1snTOkUNGzQCjaIKHn544Rg==
   dependencies:
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/divider" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
-    "@dhis2-ui/portal" "8.0.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/divider" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
+    "@dhis2-ui/portal" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/modal@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-8.0.0.tgz#003e49aeab5d80b1abe00f1b4252f33a494cc916"
-  integrity sha512-OrBBEL7jPJumtuaZ5BlD7H4Az/wlPx8psxhcyob+Lf8J3u2n5fNfQ+Aa5Dzd3jpbo6su5ukc8NCLfRzUGuZxSQ==
+"@dhis2-ui/modal@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/modal/-/modal-8.1.0.tgz#5db8c8ec2e1e341403f9d3596309414434626b23"
+  integrity sha512-F6Bw7eBGux6hNvoDe6mmoltWwfX9GEKJZ7YJELQmREE2rqG89Nn3U6sRISIUnINaudJ0ZiCcxBOOsdks5Cv1zg==
   dependencies:
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/center" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/portal" "8.0.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/center" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/portal" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/node@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-8.0.0.tgz#3d37236c5fb4aa266be570f8d76797d98111885c"
-  integrity sha512-UJ+b0D36xZrCwGSqP/g8KYowTpBo/tMZ1fyte46Z7CpsPRaPl//7XUsoIcK2+07dtuqWEZC4uFHZY4Wb9eEiog==
+"@dhis2-ui/node@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/node/-/node-8.1.0.tgz#589957b9f0c957d760877fc0d8ef1fdee886a979"
+  integrity sha512-kgb30fr74omeClEzhEs97ld9EYymj40a2t24gEHmLCJmgHgnSUcqzd2nxZvIuzxU1P681uULA93MzPW3hdu8ag==
   dependencies:
-    "@dhis2-ui/loader" "8.0.0"
+    "@dhis2-ui/loader" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/notice-box@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-8.0.0.tgz#f36b77bfba885e88d6af4e5afd6b346d2ebcfcd0"
-  integrity sha512-pFhP5dLW5JDEZ8NH5SLhRdg0eh8ot3mR0bphFDWtraFqovpgIL1fHwyrhrjvQSm7mKDgN8XKe0r2EgMRKKXT2Q==
+"@dhis2-ui/notice-box@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/notice-box/-/notice-box-8.1.0.tgz#92355e6cb00752142daac18384cf3512ea4bb554"
+  integrity sha512-dUpWTIz71aPTAWpy+1U0aj9if/VvUHfxIKH5FMmZho+UbQUZouz5DS+laheyZ/GaUSlA41NskxOB/EAqtIlf3w==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/organisation-unit-tree@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-8.0.0.tgz#966f4597509f700badb5afb0707d8398ebeabe49"
-  integrity sha512-ekBJ+Nmzpj8MuvDIG7tsDdbo2s7Wv/m2yr+c8eC2wVNKMUqggbq+j017Jf9fxiMAs04tDo+KeHa9diMILjBuFw==
+"@dhis2-ui/organisation-unit-tree@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/organisation-unit-tree/-/organisation-unit-tree-8.1.0.tgz#5f66935fcf5cda3b737d4a68e208092b86864626"
+  integrity sha512-7qbw3G5p+w2y7belOIKWGhBy8y2a0gT3LGCQ7pibOK14L0njZMOcYhXqSkx687Z2vFtN0TCJ5+kanlQBH64A5Q==
   dependencies:
-    "@dhis2-ui/checkbox" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/node" "8.0.0"
+    "@dhis2-ui/checkbox" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/node" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/pagination@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-8.0.0.tgz#1f82cefac886d13c463fec8e68fd300129223d8b"
-  integrity sha512-CldOMY9Db+okG2DWY4WUEjRz7s02CYgfP7tMq6d/vhDL/gbID3FR+zm+XUQumTaf6mu781mrKRU6lPbZvQsc7g==
+"@dhis2-ui/pagination@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/pagination/-/pagination-8.1.0.tgz#ea0e3604386ba6869071c5d4095e710f8993e4eb"
+  integrity sha512-XuJkTRHmZg9zEHrxcHf9idlqje3wEJfv6IXFA26CHiDbpzukGsChPrSRwvaBkkVZBFe8lI7LCRLcGDoJE3b0BQ==
   dependencies:
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/select" "8.0.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/select" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popover@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-8.0.0.tgz#faf0288a51445e26765b6dc499e45d043f9226ed"
-  integrity sha512-1gNA87ht74eP86XR+zPXDW8XCZTSB+MtVTu+TqdTblW3xhXkUoEQtUn6V/7ma61z4WPdOVJsch+NmbRwWv1Rdw==
+"@dhis2-ui/popover@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popover/-/popover-8.1.0.tgz#212ecbe492b1ce3329be24cdbbcf862b125f0365"
+  integrity sha512-pUId+afnrTrdUfgyA28pzUqCCexiKWBpzmkSyyD3/hFdnjuUJYU3DetRwvIvjwdI5G3FOmwQhGMroMQNxWrZ7Q==
   dependencies:
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/popper@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-8.0.0.tgz#1e9ac313655748f582b7dd5fe467877e5a2e90b5"
-  integrity sha512-hwvHhgNBtb4N3cClKj8ze9NoyCiaN4yVPGqSVdmW4yfUagXgDaKe9er1GLty+3Zmnz113flX59JzqjtZ/R6Www==
+"@dhis2-ui/popper@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/popper/-/popper-8.1.0.tgz#24bf00e51986950a7b0bf0b5c4f51a7f7824f496"
+  integrity sha512-QV+SLVd7CFcHiji9NFLHhhxUm4vnQwiQ2bIN/yGh8gtGiv3YblUWrnul582DMttmseSjjS5+SJ0/7xr77ZunYQ==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     "@popperjs/core" "^2.10.1"
     classnames "^2.3.1"
     prop-types "^15.7.2"
     react-popper "^2.2.5"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2-ui/portal@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-8.0.0.tgz#32edccd3621221e29d62bf619640c0e2065425ed"
-  integrity sha512-DgQ2A5th+952IBzhNpuoekVb6giZglbbIpXuzUUboIfFiOo69sTw/czVT8R+cb1RXJmSS+/WmsoQfx5qlSlKhQ==
+"@dhis2-ui/portal@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/portal/-/portal-8.1.0.tgz#3d477a114064e4d5a09d310b45e7025552769024"
+  integrity sha512-t13EIrRWo1CIlftRVFo3m47UZBVRmFBx/tWVDuLgrzEOW50G7TsnQV9m25VDWOay09TmeYJePq4ozo8IUVfG1g==
   dependencies:
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/radio@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-8.0.0.tgz#6bd667c9cd1fc711c96a61a66ae780b61be3244d"
-  integrity sha512-Lk3vHyZGRtwH42ntF7XOQzOHZQ56rbBvTbdLOpIUgiz4VH4ti0YVwng6V/7/8u7KY2FHJay24wTjsRDDO302Ug==
+"@dhis2-ui/radio@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/radio/-/radio-8.1.0.tgz#6aaea7fdfecf0569bda01aa3d4f5623193149585"
+  integrity sha512-st/oNzgUVcqi8QeAoz4rSO14+jqG1aDyrt2pBP9PBf3og28JIwbHyVOOsFBmQGq37YWq9iN9UqFwmBc52ob9iQ==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/required@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-8.0.0.tgz#e9831248bb2b1b4129f811878ae62dd276b6b673"
-  integrity sha512-X//2opJPu7rnkrGlmVCGfXYzOCNwrv6XkcYXK+tTZeqlmJOMghv2EwtFIay/tjdce0Dm9BbX2gGodoaT3lVyiw==
+"@dhis2-ui/required@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/required/-/required-8.1.0.tgz#82d28cc77cb3189cf2ec52857f35e1068f611bba"
+  integrity sha512-IYLEdgcUb7zw00AwrM1eQZzCNwerKJ92RYjR+u34SRt664iHHoAB4u3tWJ1sO6KBm5bg7RIWtSGq1vlBWz15VQ==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/segmented-control@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-8.0.0.tgz#98e205bc8ae8881c64870937700583a165620e76"
-  integrity sha512-cVo+8xSdIXhsrdvZN0ur2YMlWr5N01Rql0sWA+tAqwF+XrG8oro7Y5X/xTJ5Jl9gLq9Dx1swpGdqcA77KrRMBA==
+"@dhis2-ui/segmented-control@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/segmented-control/-/segmented-control-8.1.0.tgz#1047be00ba4ac01f7f96e2d67b31e4071e53690a"
+  integrity sha512-ieZD4ZAjSqeTwxd1FnmTSTpAlzXZooNFUTn1EgqfZuh8L1fNWDu8vkdGAqCFDT56HceVu3oFY49Pem8ymA/Vkw==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/select@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-8.0.0.tgz#0be118055c82b65ac5d61990080febdf13aeb5ad"
-  integrity sha512-Vo/nD5pBgE94VyyckwuZ1gkmCQs/loQUcEL1W1DPzBO2Gb5IGuCisn2cGX/YulleOKmzSPkF2D9J7OeoJNWyVg==
+"@dhis2-ui/select@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/select/-/select-8.1.0.tgz#abe20d7cb6f6452a6eb3dd4d315ba774f74d3c88"
+  integrity sha512-oqMU1PTI9Mx9o8V9mdTMkVzp/af6EoG5InVWhS+CTZNvT4G9s2Q3/5CVe3ni7smI8oSAZEYT7fsKzUG94IKDhg==
   dependencies:
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/checkbox" "8.0.0"
-    "@dhis2-ui/chip" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
-    "@dhis2-ui/status-icon" "8.0.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/checkbox" "8.1.0"
+    "@dhis2-ui/chip" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
+    "@dhis2-ui/status-icon" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/selector-bar@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-8.0.0.tgz#a276fe46b87e3ec8fae8e435c848f25270a421d1"
-  integrity sha512-vMywSS5Jq7cn3VMA1ZBS9IoiU3iN5fWI/BgA/PL5nLyn+jwpVLkQ55Gyy3hR8NVTfQTUK77i0zvup7EiEoS2OA==
+"@dhis2-ui/selector-bar@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/selector-bar/-/selector-bar-8.1.0.tgz#7424322ec0c97665ad150ada378c3bcbb211a278"
+  integrity sha512-VwaARjedyXhJQacTX2CADbcHeuBoMBmndeK02W5itqURjDW6P+XXRASeArB+q5uykuaHTnmnADLaPzzReSDTJw==
   dependencies:
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     "@testing-library/react" "^12.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/sharing-dialog@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-8.0.0.tgz#87a35dabba470cacd005dd40823ed7fb9b10d1ae"
-  integrity sha512-wcE1RZyDNt/Yx5S17C5i2pFI0DXNG25FdlNmx0CsKZHbX0fYBqFrUPxuZH4KmAna+T44RMz5POtvGtOUpST5rw==
+"@dhis2-ui/sharing-dialog@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/sharing-dialog/-/sharing-dialog-8.1.0.tgz#e0fa306b4871c4cef5e4759f720e084aa24d6bdf"
+  integrity sha512-pV2CFc8hSnCMVe1GBjcyxywlRgeRfy8EWCpiAHkCqCRmA/zAn3m4c+7/QpoEDirzeKUAOXuWJOJytQeKVCmn4w==
   dependencies:
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/divider" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/menu" "8.0.0"
-    "@dhis2-ui/modal" "8.0.0"
-    "@dhis2-ui/notice-box" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
-    "@dhis2-ui/select" "8.0.0"
-    "@dhis2-ui/tab" "8.0.0"
-    "@dhis2-ui/tooltip" "8.0.0"
-    "@dhis2-ui/user-avatar" "8.0.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/divider" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/menu" "8.1.0"
+    "@dhis2-ui/modal" "8.1.0"
+    "@dhis2-ui/notice-box" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
+    "@dhis2-ui/select" "8.1.0"
+    "@dhis2-ui/tab" "8.1.0"
+    "@dhis2-ui/tooltip" "8.1.0"
+    "@dhis2-ui/user-avatar" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     "@react-hook/size" "^2.1.2"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/status-icon@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-8.0.0.tgz#347966842c2ec5bec690e6ccc39d07b6e36ba16e"
-  integrity sha512-RlTAGIR0QhJKaJgoL6pc3eJx+J0ymTVIsbOzhK37QqDTGJDWLnedqnH5J0bCpYqK02A5NlF5+G/W4M8aNNA20w==
+"@dhis2-ui/status-icon@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/status-icon/-/status-icon-8.1.0.tgz#1626586deb7c0362c00c2f113f87022908cc139f"
+  integrity sha512-s8xAfkVSiLsK1baIxwbOIE1FFIFoeB2Td/238FHYQCQ+bSk2uTtuJ6KnFcyUOH10e4c6dI6dLxbey+Lg5A9ZGQ==
   dependencies:
-    "@dhis2-ui/loader" "8.0.0"
+    "@dhis2-ui/loader" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/switch@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-8.0.0.tgz#f6fdb21d782786270ea2ee02f88b2a4b0b155fa6"
-  integrity sha512-9V5gujYUL1UHS6Y+aJoyKeaaUmDQX+JMs1LauAABXnTPhUWJj8UQxGIB+qpUtBgz8IGUbDsnaB50kTeha/5Qgw==
+"@dhis2-ui/switch@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/switch/-/switch-8.1.0.tgz#fe4aabfb6e5369c88611b5d1e8251e890eff91c8"
+  integrity sha512-qKsn7F8nfohYuQCdCtSfsKBISsT8z6Ax5MOSNsSbG9uO7FHGgu/pD35EplKb3gAEj/pQWdjPIQ4U4Q+qBalvog==
   dependencies:
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/required" "8.0.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/required" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tab@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-8.0.0.tgz#9fa315dd006549859d09bf30ec244430f4605236"
-  integrity sha512-70v+8nxm6i7PYegmWv8AfwHQDpoPSSXjKFrMbSYIiGKswEeCwmjdwAmLoDVH8fUF1ENT19JMrmHpvXhpZ+Q6ew==
+"@dhis2-ui/tab@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tab/-/tab-8.1.0.tgz#3c8fa5d1a0246c4c20a7f25803b75930b3c45c09"
+  integrity sha512-jj6iWYyeiE//M8xEiPwHNBvACsubRJ/Sv5eAT8yo34kwubY5U8G23JYKnXFFBiEUBioalJdQCKuG5LXfVpSAug==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/table@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-8.0.0.tgz#cdd59895ed469b0a07a17f29254a58e21e2e3a44"
-  integrity sha512-2Z8uKmz8mE9vdTKyJhxXlj0YaPePizE1KsX/U6R4Hs9gLdENry8hdy+1zwMzzXfhdIqqP3lKZxBiQPIlNJqW3w==
+"@dhis2-ui/table@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/table/-/table-8.1.0.tgz#b18f193f42d6afbf5bc2ea44f33e0972e4de9447"
+  integrity sha512-rGS9XppdtnHMXhmn/c58At/7adTbXdhaHbfroIk73DHwH6UV7nTU2ln4wEpVIGDOeg3K26hHV8I8jL2s++lj1Q==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tag@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-8.0.0.tgz#ac895fa043f2bf9d5e8d59b31d620ebbdb4aa3d2"
-  integrity sha512-S58uE21+oDZt6xFdn8nMc3R12SyMPkBtelcBz0PZpB+676mHeAouixXKFjhFTCqVjQRPVUMMAjFRILXymUOVkQ==
+"@dhis2-ui/tag@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tag/-/tag-8.1.0.tgz#2ad552a31de8fcc2397c28e1c2113c644e1ebbce"
+  integrity sha512-qtdd6iiIjCvGZ5KnXRCBZhrlonBVZcGwid4OoA5CFPaHvo/0fYbXZexmBjS6NQWSUHWC7/yd9d+RAk59osP+cA==
   dependencies:
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/text-area@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-8.0.0.tgz#b460601ec0f680da3bf47d2a5d560e8803fcce79"
-  integrity sha512-cINYOd6wUO7FvwOASJxnfRgYV0FMYPEPgu4CfjnX8g+McMSiSw1E0ThoZM1n9KEQD49dQ2sEAp9qyjZ/14dtlw==
+"@dhis2-ui/text-area@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/text-area/-/text-area-8.1.0.tgz#067a5bac7dfc94110cc70c6c743cc67127bea607"
+  integrity sha512-BW0kq73EPlXW2iQa0aRBWNRv+cqrnsEzf4ekYhp0oyz8hVtyTKP2USJIpBU1YSRvfYHcNC0k9ZV1D0IRXqvS2w==
   dependencies:
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/status-icon" "8.0.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/status-icon" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/tooltip@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-8.0.0.tgz#44b1551461338027e1c766ab5097b2ae1009ef92"
-  integrity sha512-vGk/YvQ1aTq7o1y+wrONdTdJg9e2sb9XRHgbC186QwxCWP4vcHrpU9tFA0QFHrRDeXDmCGIRTJFw9flofpxjiw==
+"@dhis2-ui/tooltip@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/tooltip/-/tooltip-8.1.0.tgz#2e09b339eb6369979b69e9129b017ce42dacb2eb"
+  integrity sha512-R55qSh1Qv42eETfJwpiGJXQ/yLkuREeoy5L/xXFP2rbhXhSAhHzeEnNaesdtRcfthJfpCmCqrEI6Oe5GH6ElYQ==
   dependencies:
-    "@dhis2-ui/popper" "8.0.0"
-    "@dhis2-ui/portal" "8.0.0"
+    "@dhis2-ui/popper" "8.1.0"
+    "@dhis2-ui/portal" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/transfer@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-8.0.0.tgz#b1395f2e26d70de7de4140c73d3e43d297c54db3"
-  integrity sha512-6pVd8xI/xozdQ0WwBrzPWKt7yaPeHD48gp4tEIZqvY9uI5h/P6r/uCs20jq4D8eMtSpRa9DWlGOpZNdJvL1MXw==
+"@dhis2-ui/transfer@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/transfer/-/transfer-8.1.0.tgz#c5551ae30d49a507631bc2a53ce4b14e4eca6841"
+  integrity sha512-w1fuPtaWPD8ws75tpknbcuGzxbBuyNI6o2ejRrA95lMxADE6L6RQMi7zsfyOAz9fWsiZlbvCEE9lrhEfEYA6xw==
   dependencies:
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/intersection-detector" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/intersection-detector" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2-ui/user-avatar@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-8.0.0.tgz#1aa0ae66e1c0bb11c6643a7aa9dad3d861ed4de4"
-  integrity sha512-FMmHzk8137biXooLIuMkiJCaleG/8BeagJNMNaCbYAwPFGI5BAsUXSzxqjSCDshGouTqw8rIV3I5K1WSS32Ygg==
+"@dhis2-ui/user-avatar@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2-ui/user-avatar/-/user-avatar-8.1.0.tgz#dcf38c5bad88e115b866273b82b2f57eef8db97d"
+  integrity sha512-5wUOTkjF5GMgom3IEVUynd3z/OOjrBMF2bR9niepM7euyPNgbxwo4qr/HAbAtMzFzauXOuPnScnSbIdC1oWpmA==
   dependencies:
     "@dhis2/prop-types" "^3.0.0"
-    "@dhis2/ui-constants" "8.0.0"
+    "@dhis2/ui-constants" "8.1.0"
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
@@ -2168,90 +2168,90 @@
     workbox-routing "^6.1.5"
     workbox-strategies "^6.1.5"
 
-"@dhis2/ui-constants@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-8.0.0.tgz#9517ac76083e080cd54aeb6933ce5fb9fa87ed6a"
-  integrity sha512-J6vgVbiDh0mHnFFFBj23UEUks2r/UZrC9naDx1+r1/4+IixJNbl0XimwcM3jugBHrrP41Piaf3Uh9buRXzdsGw==
+"@dhis2/ui-constants@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-8.1.0.tgz#76cc38acec6e8d4088dcbf519c24ce41138a2bf5"
+  integrity sha512-QcUYSxRrVMKmXvXn0lBK+5j3IDl+WGFh7ZWJ1t626awVpW6f3pq/0i4M6RMDLNeVqcDrc/64ngrRnM/0JR+hqg==
   dependencies:
     prop-types "^15.7.2"
 
-"@dhis2/ui-forms@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-8.0.0.tgz#23456e157f0684e0c9d1fc30614bfdb0ed1c967f"
-  integrity sha512-JQWWHyW866/jyBDrbkjiOkwAaDYvF1vQtmvHI/fIPNregmZ395RkkYNFvF0jr75pWCq9lkEBXnDH7L9QkMi0Zw==
+"@dhis2/ui-forms@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-8.1.0.tgz#fdecc1f34d1d699f681ddac8295cf105eddcbfee"
+  integrity sha512-pzW0ELE9L4rUfZib+2umQaOz+bCWCIncKgGj06sNZGm1/4Vi5RhSf/f8GkgUzJByK8/1Pz3GuC+a0VVV8W5rhg==
   dependencies:
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/checkbox" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/file-input" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/radio" "8.0.0"
-    "@dhis2-ui/select" "8.0.0"
-    "@dhis2-ui/switch" "8.0.0"
-    "@dhis2-ui/text-area" "8.0.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/checkbox" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/file-input" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/radio" "8.1.0"
+    "@dhis2-ui/select" "8.1.0"
+    "@dhis2-ui/switch" "8.1.0"
+    "@dhis2-ui/text-area" "8.1.0"
     "@dhis2/prop-types" "^3.0.0-beta.1"
     classnames "^2.3.1"
     final-form "^4.20.2"
     prop-types "^15.7.2"
     react-final-form "^6.5.3"
 
-"@dhis2/ui-icons@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-8.0.0.tgz#3a4ff93c396da5a0a876a73c52c4e4ea3580edb9"
-  integrity sha512-bwL852EoSiKInKwDoBukspz6zSZz59C2JoN7gw5coPcMIwdqqy/v5Pqz3xAPSlOm7EQonWhPhb5HFoWckcHa2g==
+"@dhis2/ui-icons@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-8.1.0.tgz#8c7d618fb67c63f39bb23633770b356594e30d2c"
+  integrity sha512-Hv7qxp8KFCQdgGJW0X/RBmEUWUYMFebupdrqTz7DuwMcsWZHWQGn+TojHqT0RcipyS2O+WUeMrWqIcnrPVmdAA==
 
-"@dhis2/ui@^7.2.0", "@dhis2/ui@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-8.0.0.tgz#64a70042023a75d6d9278cf4d57dd536c1d30f65"
-  integrity sha512-uo9bKUinqTtREMM4K0dyoQZjtuvHugbHpm8WC3xeRZ1ooMNEb6lWrNk/hcWZ5KOteo/hdnTtA4hTeV/xehWq4Q==
+"@dhis2/ui@^7.2.0", "@dhis2/ui@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-8.1.0.tgz#b93628e0e66a0eb604b9ed4dc2c66475001537ac"
+  integrity sha512-eU8ZwMMJRN0xITFLT3BNi6oYXbib3T0l0dqOxZ87t82/A7vOYBX8pw06ybIKCIL4c4/TB6idL8hLoO8A7OoMpQ==
   dependencies:
-    "@dhis2-ui/alert" "8.0.0"
-    "@dhis2-ui/box" "8.0.0"
-    "@dhis2-ui/button" "8.0.0"
-    "@dhis2-ui/card" "8.0.0"
-    "@dhis2-ui/center" "8.0.0"
-    "@dhis2-ui/checkbox" "8.0.0"
-    "@dhis2-ui/chip" "8.0.0"
-    "@dhis2-ui/cover" "8.0.0"
-    "@dhis2-ui/css" "8.0.0"
-    "@dhis2-ui/divider" "8.0.0"
-    "@dhis2-ui/field" "8.0.0"
-    "@dhis2-ui/file-input" "8.0.0"
-    "@dhis2-ui/header-bar" "8.0.0"
-    "@dhis2-ui/help" "8.0.0"
-    "@dhis2-ui/input" "8.0.0"
-    "@dhis2-ui/intersection-detector" "8.0.0"
-    "@dhis2-ui/label" "8.0.0"
-    "@dhis2-ui/layer" "8.0.0"
-    "@dhis2-ui/legend" "8.0.0"
-    "@dhis2-ui/loader" "8.0.0"
-    "@dhis2-ui/logo" "8.0.0"
-    "@dhis2-ui/menu" "8.0.0"
-    "@dhis2-ui/modal" "8.0.0"
-    "@dhis2-ui/node" "8.0.0"
-    "@dhis2-ui/notice-box" "8.0.0"
-    "@dhis2-ui/organisation-unit-tree" "8.0.0"
-    "@dhis2-ui/pagination" "8.0.0"
-    "@dhis2-ui/popover" "8.0.0"
-    "@dhis2-ui/popper" "8.0.0"
-    "@dhis2-ui/portal" "8.0.0"
-    "@dhis2-ui/radio" "8.0.0"
-    "@dhis2-ui/required" "8.0.0"
-    "@dhis2-ui/segmented-control" "8.0.0"
-    "@dhis2-ui/select" "8.0.0"
-    "@dhis2-ui/selector-bar" "8.0.0"
-    "@dhis2-ui/sharing-dialog" "8.0.0"
-    "@dhis2-ui/switch" "8.0.0"
-    "@dhis2-ui/tab" "8.0.0"
-    "@dhis2-ui/table" "8.0.0"
-    "@dhis2-ui/tag" "8.0.0"
-    "@dhis2-ui/text-area" "8.0.0"
-    "@dhis2-ui/tooltip" "8.0.0"
-    "@dhis2-ui/transfer" "8.0.0"
-    "@dhis2-ui/user-avatar" "8.0.0"
-    "@dhis2/ui-constants" "8.0.0"
-    "@dhis2/ui-forms" "8.0.0"
-    "@dhis2/ui-icons" "8.0.0"
+    "@dhis2-ui/alert" "8.1.0"
+    "@dhis2-ui/box" "8.1.0"
+    "@dhis2-ui/button" "8.1.0"
+    "@dhis2-ui/card" "8.1.0"
+    "@dhis2-ui/center" "8.1.0"
+    "@dhis2-ui/checkbox" "8.1.0"
+    "@dhis2-ui/chip" "8.1.0"
+    "@dhis2-ui/cover" "8.1.0"
+    "@dhis2-ui/css" "8.1.0"
+    "@dhis2-ui/divider" "8.1.0"
+    "@dhis2-ui/field" "8.1.0"
+    "@dhis2-ui/file-input" "8.1.0"
+    "@dhis2-ui/header-bar" "8.1.0"
+    "@dhis2-ui/help" "8.1.0"
+    "@dhis2-ui/input" "8.1.0"
+    "@dhis2-ui/intersection-detector" "8.1.0"
+    "@dhis2-ui/label" "8.1.0"
+    "@dhis2-ui/layer" "8.1.0"
+    "@dhis2-ui/legend" "8.1.0"
+    "@dhis2-ui/loader" "8.1.0"
+    "@dhis2-ui/logo" "8.1.0"
+    "@dhis2-ui/menu" "8.1.0"
+    "@dhis2-ui/modal" "8.1.0"
+    "@dhis2-ui/node" "8.1.0"
+    "@dhis2-ui/notice-box" "8.1.0"
+    "@dhis2-ui/organisation-unit-tree" "8.1.0"
+    "@dhis2-ui/pagination" "8.1.0"
+    "@dhis2-ui/popover" "8.1.0"
+    "@dhis2-ui/popper" "8.1.0"
+    "@dhis2-ui/portal" "8.1.0"
+    "@dhis2-ui/radio" "8.1.0"
+    "@dhis2-ui/required" "8.1.0"
+    "@dhis2-ui/segmented-control" "8.1.0"
+    "@dhis2-ui/select" "8.1.0"
+    "@dhis2-ui/selector-bar" "8.1.0"
+    "@dhis2-ui/sharing-dialog" "8.1.0"
+    "@dhis2-ui/switch" "8.1.0"
+    "@dhis2-ui/tab" "8.1.0"
+    "@dhis2-ui/table" "8.1.0"
+    "@dhis2-ui/tag" "8.1.0"
+    "@dhis2-ui/text-area" "8.1.0"
+    "@dhis2-ui/tooltip" "8.1.0"
+    "@dhis2-ui/transfer" "8.1.0"
+    "@dhis2-ui/user-avatar" "8.1.0"
+    "@dhis2/ui-constants" "8.1.0"
+    "@dhis2/ui-forms" "8.1.0"
+    "@dhis2/ui-icons" "8.1.0"
     prop-types "^15.7.2"
 
 "@dnd-kit/accessibility@^3.0.0":


### PR DESCRIPTION
Implements client side work of [DHIS2-12529](https://jira.dhis2.org/browse/DHIS2-12529)

---

### Key features

1. Upgrades `@dhis2/ui` to `8.1.0` which includes support for pagers without a total in the `Pagination` component
2. Adds `totalPages=false` query param to the analytics request (not working yet)
3. Updates the props passed to`Pagination` to align with the new pager object shape

### Known issues

-   [ ] This isn't working yet because the backend is still returning a full pager object (with totals) after adding the query params.

---

### Screenshots

_Can be added once the backend issue is fixed_
