### PR TITLE
fix: migrate away from deprecated userCredentials object (DHIS2-17631)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-reports-app#readme",
   "dependencies": {
-    "d2-analysis": "^33.3.1",
+    "d2-analysis": "^33.3.2",
     "d2-utilizr": "0.2.13"
   },
   "devDependencies": {
@@ -66,7 +66,7 @@
       "dhis": {
         "href": "..",
         "auth": "admin:district",
-        "devHref": "https://debug.dhis2.org/dev"
+        "devHref": "http://localhost:8080"
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,10 +1734,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@^33.3.1:
-  version "33.3.1"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.3.1.tgz#6299beb6b79bc252d21c535db86ccab301700c95"
-  integrity sha512-VhGB5BWiyZrGFpwRDOMJt0SpK0mboFe50VGE7GRUP8JzqGNUG0FXxuzC5wepKcPuPOEimU+PjrqGtmPZFBo0XQ==
+d2-analysis@^33.3.2:
+  version "33.3.2"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.3.2.tgz#2497f20a9630a07ca68472496fe44a62e6367700"
+  integrity sha512-TegC9xvkBcTYnFDxzJoqqLW50kSYSqT8qBzH/4DdeaSbLB0X0h3VLf61nmVux7Vt3jI/lry38FnFWBp70CgODg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
Fixes [DHIS2-17631](https://jira.dhis2.org/browse/DHIS2-17631)

[DHIS2-17631]: https://dhis2.atlassian.net/browse/DHIS2-17631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ