### PR TITLE
fix: add base target top (DHIS2-19274)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <title>DHIS 2 Event Reports</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="initial-scale=1"/>
+    <base target="_top">
 </head>
 <body class="event-reports-app">
 <div id="init">


### PR DESCRIPTION
Implements [DHIS2-19274](https://jira.dhis2.org/browse/DHIS2-19274)

Sets base target to `_top` to make links work in the dhis2 global shell.


[DHIS2-19274]: https://dhis2.atlassian.net/browse/DHIS2-19274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ